### PR TITLE
Replaced scalafmtCheck for scalafmtCheckAll

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
         uses: japgolly/setup-everything-scala@v1.0
 
       - name: Check code format
-        run: sbt scalafmtCheck
+        run: sbt scalafmtCheckAll
 
       - name: Compile
         run: sbt compile


### PR DESCRIPTION
In contrast to scalafmtCheck, scalafmtCheckAll checks every configurations in which it is enabled