### PR TITLE
Fix compile warnings on the sjs swagger annotations

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Scala
-        uses: japgolly/setup-everything-scala@v1.0
+        uses: japgolly/setup-everything-scala@v3.1
+        with:
+          java-version: 'adopt:1.11.0-11'
+          node-version: '16.7.0'
 
       - name: Check code format
         run: sbt scalafmtCheckAll

--- a/lib/api/js/src/main/scala/io/swagger/annotations/ApiModel.scala
+++ b/lib/api/js/src/main/scala/io/swagger/annotations/ApiModel.scala
@@ -4,6 +4,9 @@ import scala.annotation.Annotation
 
 // Dummy annotation to allow using swagger-annotations in our sjs compiled models
 // Based on https://github.com/swagger-api/swagger-core
+//
+// NOTE: Due to a compiler bug, we must define the values in the order we expect them to be used
+//       otherwise, we end up with compile warnings - https://github.com/scala/bug/issues/7656
 @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
 final case class ApiModel(
     value: String = "",

--- a/lib/api/js/src/main/scala/io/swagger/annotations/ApiModelProperty.scala
+++ b/lib/api/js/src/main/scala/io/swagger/annotations/ApiModelProperty.scala
@@ -10,18 +10,21 @@ package io.swagger.annotations
 
 // Dummy annotation to allow using swagger-annotations in our sjs compiled models
 // Based on https://github.com/swagger-api/swagger-core
+//
+// NOTE: Due to a compiler bug, we must define the values in the order we expect them to be used
+//       otherwise, we end up with compile warnings - https://github.com/scala/bug/issues/7656
 @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
 case class ApiModelProperty(
     value: String = "",
+    dataType: String = "",
+    example: String = "",
     name: String = "",
     allowableValues: String = "",
     access: String = "",
     notes: String = "",
-    dataType: String = "",
     required: Boolean = false,
     position: Int = 0,
     hidden: Boolean = false,
-    example: String = "",
     readOnly: Boolean = false,
     accessMode: ApiModelProperty.AccessMode.AccessMode = ApiModelProperty.AccessMode.AUTO,
     reference: String = "",

--- a/lib/api/js/src/main/scala/io/swagger/annotations/Extension.scala
+++ b/lib/api/js/src/main/scala/io/swagger/annotations/Extension.scala
@@ -10,5 +10,8 @@ package io.swagger.annotations
 
 // Dummy annotation to allow using swagger-annotations in our sjs compiled models
 // Based on https://github.com/swagger-api/swagger-core
+//
+// NOTE: Due to a compiler bug, we must define the values in the order we expect them to be used
+//       otherwise, we end up with compile warnings - https://github.com/scala/bug/issues/7656
 @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
 case class Extension(name: String = "", properties: Array[ExtensionProperty]) extends scala.annotation.Annotation

--- a/lib/api/js/src/main/scala/io/swagger/annotations/ExtensionProperty.scala
+++ b/lib/api/js/src/main/scala/io/swagger/annotations/ExtensionProperty.scala
@@ -10,5 +10,8 @@ package io.swagger.annotations
 
 // Dummy annotation to allow using swagger-annotations in our sjs compiled models
 // Based on https://github.com/swagger-api/swagger-core
+//
+// NOTE: Due to a compiler bug, we must define the values in the order we expect them to be used
+//       otherwise, we end up with compile warnings - https://github.com/scala/bug/issues/7656
 case class ExtensionProperty(name: String, value: String, parseValue: Boolean = false)
     extends scala.annotation.Annotation

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/models/CreateUser.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/models/CreateUser.scala
@@ -7,13 +7,14 @@ import play.api.libs.json.{Format, Json}
 import java.util.UUID
 
 object CreateUser {
+//  @SuppressWarnings(Array("org.wartremover.warts.ArrayEquals"))
   @ApiModel(value = "CreateUserRequest", description = "Request for the create user API")
   case class Request(
-      @ApiModelProperty(value = "The user's name", example = "Alex", dataType = "String")
+      @ApiModelProperty(value = "The user's name", dataType = "String", example = "Alex")
       name: Name,
-      @ApiModelProperty(value = "The user's email", example = "email@wiringbits.net", dataType = "String")
+      @ApiModelProperty(value = "The user's email", dataType = "String", example = "email@wiringbits.net")
       email: Email,
-      @ApiModelProperty(value = "The user's password", example = "notSoWeakPassword", dataType = "String")
+      @ApiModelProperty(value = "The user's password", dataType = "String", example = "notSoWeakPassword")
       password: Password,
       @ApiModelProperty(value = "The ReCAPTCHA value", dataType = "String")
       captcha: Captcha

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/models/Login.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/models/Login.scala
@@ -10,9 +10,9 @@ object Login {
 
   @ApiModel(value = "LoginRequest", description = "Request to log into the app")
   case class Request(
-      @ApiModelProperty(value = "The user's email", example = "alexis@wiringbits.net", dataType = "String")
+      @ApiModelProperty(value = "The user's email", dataType = "String", example = "alexis@wiringbits.net")
       email: Email,
-      @ApiModelProperty(value = "The user's password", example = "notSoWeakPassword", dataType = "String")
+      @ApiModelProperty(value = "The user's password", dataType = "String", example = "notSoWeakPassword")
       password: Password,
       @ApiModelProperty(value = "The ReCAPTCHA value", dataType = "String")
       captcha: Captcha

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/models/ResetPassword.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/models/ResetPassword.scala
@@ -14,7 +14,7 @@ object ResetPassword {
 
   @ApiModel(value = "ResetPasswordResponse", description = "Response after resetting a user password")
   case class Response(
-      @ApiModelProperty(value = "The user's name", example = "Alex", dataType = "String")
+      @ApiModelProperty(value = "The user's name", dataType = "String", example = "Alex")
       name: Name,
       @ApiModelProperty(value = "The user's email", dataType = "String")
       email: Email,

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/models/UpdateUser.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/models/UpdateUser.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{Format, Json}
 object UpdateUser {
 
   @ApiModel(value = "UpdateUserRequest", description = "Request to update user details")
-  case class Request(@ApiModelProperty(value = "The user's name", example = "Alex", dataType = "String") name: Name)
+  case class Request(@ApiModelProperty(value = "The user's name", dataType = "String", example = "Alex") name: Name)
 
   @ApiModel(value = "UpdateUserResponse", description = "Response after updating the user details")
   case class Response(noData: String = "")


### PR DESCRIPTION
There is a weird behavior from the compiler which prevent using named
arguments while annotating code, in order to avoid such issue, we must
define the arguments in the order they are defined.