### PR TITLE
Refactor the authentication layer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -337,7 +337,12 @@ lazy val server = (project in file("server"))
       "software.amazon.awssdk" % "ses" % "2.17.141",
       "jakarta.xml.bind" % "jakarta.xml.bind-api" % "3.0.1",
       "org.apache.commons" % "commons-text" % "1.9",
-      "io.swagger" % "swagger-annotations" % swagger
+      "io.swagger" % "swagger-annotations" % swagger,
+      // JAX-B dependencies for JDK 9+, required to use play sessions
+      "javax.xml.bind" % "jaxb-api" % "2.3.1",
+      "javax.annotation" % "javax.annotation-api" % "1.3.2",
+      "javax.el" % "javax.el-api" % "3.0.0",
+      "org.glassfish" % "javax.el" % "3.0.0"
     )
   )
 

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/ApiClient.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/ApiClient.scala
@@ -13,6 +13,7 @@ trait ApiClient {
   def createUser(request: CreateUser.Request): Future[CreateUser.Response]
   def login(request: Login.Request): Future[Login.Response]
   def loginBrowser(request: Login.Request): Future[Login.Response]
+  def logoutBrowser(): Future[Logout.Response]
 
   def verifyEmail(request: VerifyEmail.Request): Future[VerifyEmail.Response]
   def forgotPassword(request: ForgotPassword.Request): Future[ForgotPassword.Response]
@@ -135,7 +136,7 @@ object ApiClient {
     }
 
     override def login(request: Login.Request): Future[Login.Response] = {
-      val path = ServerAPI.path :+ "users" :+ "login"
+      val path = ServerAPI.path :+ "auth" :+ "login"
       val uri = ServerAPI.withPath(path)
 
       prepareRequest[Login.Response]
@@ -147,7 +148,7 @@ object ApiClient {
     }
 
     override def loginBrowser(request: Login.Request): Future[Login.Response] = {
-      val path = ServerAPI.path :+ "users" :+ "login" :+ "browser"
+      val path = ServerAPI.path :+ "auth" :+ "login-browser"
       val uri = ServerAPI.withPath(path)
 
       prepareRequest[Login.Response]
@@ -158,8 +159,20 @@ object ApiClient {
         .flatMap(Future.fromTry)
     }
 
+    override def logoutBrowser(): Future[Logout.Response] = {
+      val path = ServerAPI.path :+ "auth" :+ "logout-browser"
+      val uri = ServerAPI.withPath(path)
+
+      prepareRequest[Logout.Response]
+        .post(uri)
+        .body(Json.toJson(Logout.Request()).toString())
+        .send(backend)
+        .map(_.body)
+        .flatMap(Future.fromTry)
+    }
+
     override def currentUser(jwt: String): Future[GetCurrentUser.Response] = {
-      val path = ServerAPI.path :+ "users" :+ "me"
+      val path = ServerAPI.path :+ "auth" :+ "me"
       val uri = ServerAPI.withPath(path)
 
       prepareRequest[GetCurrentUser.Response]

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/ApiClient.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/ApiClient.scala
@@ -12,6 +12,7 @@ import scala.util.{Failure, Success, Try}
 trait ApiClient {
   def createUser(request: CreateUser.Request): Future[CreateUser.Response]
   def login(request: Login.Request): Future[Login.Response]
+  def loginBrowser(request: Login.Request): Future[Login.Response]
 
   def verifyEmail(request: VerifyEmail.Request): Future[VerifyEmail.Response]
   def forgotPassword(request: ForgotPassword.Request): Future[ForgotPassword.Response]
@@ -135,6 +136,18 @@ object ApiClient {
 
     override def login(request: Login.Request): Future[Login.Response] = {
       val path = ServerAPI.path :+ "users" :+ "login"
+      val uri = ServerAPI.withPath(path)
+
+      prepareRequest[Login.Response]
+        .post(uri)
+        .body(Json.toJson(request).toString())
+        .send(backend)
+        .map(_.body)
+        .flatMap(Future.fromTry)
+    }
+
+    override def loginBrowser(request: Login.Request): Future[Login.Response] = {
+      val path = ServerAPI.path :+ "users" :+ "login" :+ "browser"
       val uri = ServerAPI.withPath(path)
 
       prepareRequest[Login.Response]

--- a/lib/api/shared/src/main/scala/net/wiringbits/api/models/Logout.scala
+++ b/lib/api/shared/src/main/scala/net/wiringbits/api/models/Logout.scala
@@ -1,0 +1,16 @@
+package net.wiringbits.api.models
+
+import io.swagger.annotations._
+import play.api.libs.json.{Format, Json}
+
+object Logout {
+
+  @ApiModel(value = "LogoutRequest", description = "Request to log out of the app")
+  case class Request(noData: String = "")
+
+  @ApiModel(value = "LogoutResponse", description = "Response after logging out of the app")
+  case class Response(noData: String = "")
+
+  implicit val logoutRequestFormat: Format[Request] = Json.format[Request]
+  implicit val logoutResponseFormat: Format[Response] = Json.format[Response]
+}

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -29,10 +29,28 @@ play.filters.hosts {
 }
 
 play.http {
-  secret.key="this doesn't matter no sessions are being used"
-  secret.key=${?PLAY_APPLICATION_SECRET}
+  # Important for production, it is used to sign sessions
+  secret.key = "changeme"
+  secret.key = ${?PLAY_APPLICATION_SECRET}
 
   errorHandler = "play.api.http.JsonHttpErrorHandler"
+
+  session {
+    cookieName = "__APP_SESSION__"
+
+    # false by default because we use http locally, must be true in prod
+    secure = false
+    secure = ${?PLAY_SESSION_SECURE}
+
+    # to secure the cookie, this value should be set in prod
+    domain = null
+    domain = ${?PLAY_SESSION_DOMAIN}
+
+    # The session path
+    # Must start with /.
+    path = ${play.http.context}
+    path = ${?PLAY_SESSION_DOMAIN_PATH}
+  }
 }
 
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
@@ -107,6 +125,14 @@ play.modules.enabled += "net.wiringbits.webapp.utils.admin.modules.ExecutorsModu
 jwt {
   secret = "changeMeBeforeRelease"
   secret = ${?JWT_SECRET}
+
+  # This is important for local development but must be set to false in production
+  #
+  # When this flag is true, the user jwt will be returned to the browser which allows
+  # the webapp (localhost:8080) to authenticate requests to the backend (localhost:9000)
+  # once we fix the cookie propagation issue, this flag should not be required anymore.
+  enforced = true
+  enforced = ${?JWT_ENFORCED}
 }
 
 email {

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -8,8 +8,10 @@ GET /swagger.json        controllers.Assets.at(path="/public", file="swagger.jso
 
 # create new user (public)
 POST /users controllers.UsersController.create()
-# login user (public)
-POST /users/login controllers.UsersController.login()
+# login user - browser (public)
+POST /users/login/browser controllers.UsersController.loginBrowser()
+# login user - api (public)
+POST /users/login controllers.UsersController.loginApi()
 # verify new user's email
 POST /users/verify-email controllers.UsersController.verifyEmail()
 # send a link to reset user's password

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -6,12 +6,17 @@
 GET /health controllers.HealthController.check()
 GET /swagger.json        controllers.Assets.at(path="/public", file="swagger.json")
 
+# login user - browser (public)
+POST /auth/login-browser controllers.AuthController.loginBrowser()
+# login user - api (public)
+POST /auth/login controllers.AuthController.loginApi()
+# logout - browser (public)
+POST /auth/logout-browser controllers.AuthController.logoutBrowser()
+# get the current user details
+GET  /auth/me controllers.AuthController.getCurrentUser()
+
 # create new user (public)
 POST /users controllers.UsersController.create()
-# login user - browser (public)
-POST /users/login/browser controllers.UsersController.loginBrowser()
-# login user - api (public)
-POST /users/login controllers.UsersController.loginApi()
 # verify new user's email
 POST /users/verify-email controllers.UsersController.verifyEmail()
 # send a link to reset user's password
@@ -21,8 +26,6 @@ POST /users/reset-password controllers.UsersController.resetPassword()
 # send email verification token (public)
 POST /users/email-verification-token controllers.UsersController.sendEmailVerificationToken()
 
-# get the current user details
-GET /users/me controllers.UsersController.getCurrentUser()
 # update the current user details
 PUT /users/me controllers.UsersController.update()
 # update the current user password
@@ -37,11 +40,11 @@ GET /admin/users controllers.AdminController.getUsers()
 # get user logs
 GET /admin/users/:userId/logs controllers.AdminController.getUserLogs(userId)
 
-# routes for admin tables (GET, POST, PUT and DELETE)
--> / net.wiringbits.webapp.utils.admin.AppRouter
-
 # get frontend configs
 GET /environment-config controllers.EnvironmentConfigController.getEnvironmentConfig()
 
 # static assets for swagger-ui
 GET /docs/*file        controllers.Assets.at(path="/swagger-ui", file)
+
+# routes for admin tables (GET, POST, PUT and DELETE)
+-> / net.wiringbits.webapp.utils.admin.AppRouter

--- a/server/src/main/scala/controllers/AuthController.scala
+++ b/server/src/main/scala/controllers/AuthController.scala
@@ -1,0 +1,159 @@
+package controllers
+
+import io.swagger.annotations._
+import net.wiringbits.actions._
+import net.wiringbits.api.models._
+import net.wiringbits.config.JwtConfig
+import org.slf4j.LoggerFactory
+import play.api.libs.json.Json
+import play.api.mvc.{AbstractController, ControllerComponents}
+
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+
+@SwaggerDefinition(
+  securityDefinition = new SecurityDefinition(
+    apiKeyAuthDefinitions = Array(
+      new ApiKeyAuthDefinition(
+        name = "Authorization",
+        key = "user_jwt",
+        in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER,
+        description = "The user's JWT retrieved when logging into the app"
+      )
+    )
+  )
+)
+@Api("Auth")
+class AuthController @Inject() (
+    loginAction: LoginAction,
+    getUserAction: GetUserAction
+)(implicit cc: ControllerComponents, ec: ExecutionContext, jwtConfig: JwtConfig)
+    extends AbstractController(cc) {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  @ApiOperation(
+    value = "Log into the app - API",
+    notes = "Returns a JWT to authenticate following requests"
+  )
+  @ApiImplicitParams(
+    Array(
+      new ApiImplicitParam(
+        name = "body",
+        value = "JSON-encoded request",
+        required = true,
+        paramType = "body",
+        dataTypeClass = classOf[Login.Request]
+      )
+    )
+  )
+  @ApiResponses(
+    Array(
+      new ApiResponse(code = 200, message = "Successful login", response = classOf[Login.Response]),
+      new ApiResponse(code = 400, message = "Invalid or missing arguments")
+    )
+  )
+  def loginApi() = handleJsonBody[Login.Request] { request =>
+    val body = request.body
+    logger.info(s"Login API: ${body.email}")
+    for {
+      response <- loginAction(body)
+    } yield Ok(Json.toJson(response))
+  }
+
+  @ApiOperation(
+    value = "Log into the app - Browser",
+    notes = "Returns a session cookie that's stored securely by the browser"
+  )
+  @ApiImplicitParams(
+    Array(
+      new ApiImplicitParam(
+        name = "body",
+        value = "JSON-encoded request",
+        required = true,
+        paramType = "body",
+        dataTypeClass = classOf[Login.Request]
+      )
+    )
+  )
+  @ApiResponses(
+    Array(
+      new ApiResponse(code = 200, message = "Successful login", response = classOf[Login.Response]),
+      new ApiResponse(code = 400, message = "Invalid or missing arguments")
+    )
+  )
+  def loginBrowser() = handleJsonBody[Login.Request] { request =>
+    val body = request.body
+    logger.info(s"Login Browser: ${body.email}")
+    for {
+      response <- loginAction(body)
+    } yield {
+      // for browsers, the jwt is not required because the userId goes into the session
+      // returning the jwt could allow js to touch the token which is what we are intending to avoid
+      //
+      // unfortunately, we have problems with the cookie propagation, which is why we keep the token
+      // while running the app locally.
+      val jwt = if (jwtConfig.enforced) {
+        logger.warn(
+          s"Browser login successful for ${body.email}, be aware that the jwt was propagated to the browser which should not occur in production"
+        )
+        response.token
+      } else {
+        ""
+      }
+
+      Ok(Json.toJson(response.copy(token = jwt)))
+        .withSession("id" -> response.id.toString)
+    }
+  }
+
+  @ApiOperation(
+    value = "Logout from the app - Browser",
+    notes = "Clears the session cookie that's stored securely by the browser",
+    authorizations = Array(new Authorization(value = "user_jwt"))
+  )
+  @ApiImplicitParams(
+    Array(
+      new ApiImplicitParam(
+        name = "body",
+        value = "JSON-encoded request",
+        required = true,
+        paramType = "body",
+        dataTypeClass = classOf[Logout.Request]
+      )
+    )
+  )
+  @ApiResponses(
+    Array(
+      new ApiResponse(code = 200, message = "Successful logout", response = classOf[Logout.Response]),
+      new ApiResponse(code = 400, message = "Invalid or missing arguments")
+    )
+  )
+  def logoutBrowser() = handleJsonBody[Logout.Request] { request =>
+    for {
+      userId <- authenticate(request)
+      user <- getUserAction(userId)
+    } yield {
+      logger.info(s"Logout Browser - ${user.email}")
+
+      Ok(Json.toJson(Logout.Response())).withNewSession
+    }
+  }
+
+  @ApiOperation(
+    value = "Get the details for the authenticated user",
+    authorizations = Array(new Authorization(value = "user_jwt"))
+  )
+  @ApiResponses(
+    Array(
+      new ApiResponse(code = 200, message = "Got user details", response = classOf[GetCurrentUser.Response]),
+      new ApiResponse(code = 400, message = "Authentication failed")
+    )
+  )
+  def getCurrentUser() = handleGET { request =>
+    for {
+      userId <- authenticate(request)
+      _ = logger.info(s"Get user info: $userId")
+      response <- getUserAction(userId)
+    } yield Ok(Json.toJson(response))
+  }
+}

--- a/server/src/main/scala/controllers/UsersController.scala
+++ b/server/src/main/scala/controllers/UsersController.scala
@@ -27,12 +27,10 @@ import scala.concurrent.ExecutionContext
 class UsersController @Inject() (
     createUserAction: CreateUserAction,
     verifyUserEmailAction: VerifyUserEmailAction,
-    loginAction: LoginAction,
     forgotPasswordAction: ForgotPasswordAction,
     resetPasswordAction: ResetPasswordAction,
     updateUserAction: UpdateUserAction,
     updatePasswordAction: UpdatePasswordAction,
-    getUserAction: GetUserAction,
     getUserLogsAction: GetUserLogsAction,
     sendEmailVerificationTokenAction: SendEmailVerificationTokenAction
 )(implicit cc: ControllerComponents, ec: ExecutionContext, jwtConfig: JwtConfig)
@@ -100,81 +98,6 @@ class UsersController @Inject() (
     for {
       response <- verifyUserEmailAction(token.userId, token.token)
     } yield Ok(Json.toJson(response))
-  }
-
-  @ApiOperation(
-    value = "Log into the app - API",
-    notes = "Returns a JWT to authenticate following requests"
-  )
-  @ApiImplicitParams(
-    Array(
-      new ApiImplicitParam(
-        name = "body",
-        value = "JSON-encoded request",
-        required = true,
-        paramType = "body",
-        dataTypeClass = classOf[Login.Request]
-      )
-    )
-  )
-  @ApiResponses(
-    Array(
-      new ApiResponse(code = 200, message = "Successful login", response = classOf[Login.Response]),
-      new ApiResponse(code = 400, message = "Invalid or missing arguments")
-    )
-  )
-  def loginApi() = handleJsonBody[Login.Request] { request =>
-    val body = request.body
-    logger.info(s"Login API: ${body.email}")
-    for {
-      response <- loginAction(body)
-    } yield Ok(Json.toJson(response))
-  }
-
-  @ApiOperation(
-    value = "Log into the app - Browser",
-    notes = "Returns a session cookie that's stored securely by the browser"
-  )
-  @ApiImplicitParams(
-    Array(
-      new ApiImplicitParam(
-        name = "body",
-        value = "JSON-encoded request",
-        required = true,
-        paramType = "body",
-        dataTypeClass = classOf[Login.Request]
-      )
-    )
-  )
-  @ApiResponses(
-    Array(
-      new ApiResponse(code = 200, message = "Successful login", response = classOf[Login.Response]),
-      new ApiResponse(code = 400, message = "Invalid or missing arguments")
-    )
-  )
-  def loginBrowser() = handleJsonBody[Login.Request] { request =>
-    val body = request.body
-    logger.info(s"Login Browser: ${body.email}")
-    for {
-      response <- loginAction(body)
-    } yield {
-      // for browsers, the jwt is not required because the userId goes into the session
-      // returning the jwt could allow js to touch the token which is what we are intending to avoid
-      //
-      // unfortunately, we have problems with the cookie propagation, which is why we keep the token
-      // while running the app locally.
-      val jwt = if (jwtConfig.enforced) {
-        logger.warn(
-          s"Browser login successful for ${body.email}, be aware that the jwt was propagated to the browser which should not occur in production"
-        )
-        response.token
-      } else {
-        ""
-      }
-
-      Ok(Json.toJson(response.copy(token = jwt)))
-        .withSession("id" -> response.id.toString)
-    }
   }
 
   @ApiOperation(
@@ -344,24 +267,6 @@ class UsersController @Inject() (
       _ = logger.info(s"Update password for: $userId")
       _ <- updatePasswordAction(userId, body)
       response = UpdateUser.Response()
-    } yield Ok(Json.toJson(response))
-  }
-
-  @ApiOperation(
-    value = "Get the details for the authenticated user",
-    authorizations = Array(new Authorization(value = "user_jwt"))
-  )
-  @ApiResponses(
-    Array(
-      new ApiResponse(code = 200, message = "Got user details", response = classOf[GetCurrentUser.Response]),
-      new ApiResponse(code = 400, message = "Authentication failed")
-    )
-  )
-  def getCurrentUser() = handleGET { request =>
-    for {
-      userId <- authenticate(request)
-      _ = logger.info(s"Get user info: $userId")
-      response <- getUserAction(userId)
     } yield Ok(Json.toJson(response))
   }
 

--- a/server/src/main/scala/net/wiringbits/config/JwtConfig.scala
+++ b/server/src/main/scala/net/wiringbits/config/JwtConfig.scala
@@ -3,10 +3,9 @@ package net.wiringbits.config
 import net.wiringbits.models.JwtSecret
 import play.api.Configuration
 
-case class JwtConfig(secret: JwtSecret) {
+case class JwtConfig(secret: JwtSecret, enforced: Boolean) {
   override def toString: String = {
-
-    s"JwtConfig(secret = ${secret.toString})"
+    s"JwtConfig(secret = ${secret.toString}, enforced = $enforced (must be false in production))"
   }
 }
 
@@ -14,6 +13,7 @@ object JwtConfig {
 
   def apply(config: Configuration): JwtConfig = {
     val secret = config.get[String]("secret")
-    JwtConfig(JwtSecret(secret))
+    val enforced = config.get[Boolean]("enforced")
+    JwtConfig(JwtSecret(secret), enforced)
   }
 }

--- a/server/src/test/scala/controllers/AuthControllerSpec.scala
+++ b/server/src/test/scala/controllers/AuthControllerSpec.scala
@@ -1,0 +1,236 @@
+package controllers
+
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import controllers.common.PlayPostgresSpec
+import net.wiringbits.api.models.{CreateUser, Login, VerifyEmail}
+import net.wiringbits.apis.models.EmailRequest
+import net.wiringbits.apis.{EmailApi, ReCaptchaApi}
+import net.wiringbits.common.models._
+import net.wiringbits.config.UserTokensConfig
+import net.wiringbits.repositories.UserTokensRepository
+import net.wiringbits.util.TokenGenerator
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar.{mock, when}
+import play.api.inject
+import play.api.inject.guice.GuiceApplicationBuilder
+import utils.LoginUtils
+
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant}
+import java.util.UUID
+import scala.concurrent.Future
+
+class AuthControllerSpec extends PlayPostgresSpec with LoginUtils {
+
+  def userTokensRepository: UserTokensRepository = app.injector.instanceOf(classOf[UserTokensRepository])
+
+  private val clock = mock[Clock]
+  when(clock.instant()).thenReturn(Instant.now())
+
+  private val tokenGenerator = mock[TokenGenerator]
+
+  private val emailApi = mock[EmailApi]
+  when(emailApi.sendEmail(any[EmailRequest]())).thenReturn(Future.unit)
+
+  private val captchaApi = mock[ReCaptchaApi]
+  when(captchaApi.verify(any[Captcha]())).thenReturn(Future.successful(true))
+
+  override def guiceApplicationBuilder(container: PostgreSQLContainer): GuiceApplicationBuilder =
+    super
+      .guiceApplicationBuilder(container)
+      .overrides(
+        inject.bind[EmailApi].to(emailApi),
+        inject.bind[ReCaptchaApi].to(captchaApi),
+        inject.bind[Clock].to(clock),
+        inject.bind[TokenGenerator].to(tokenGenerator)
+      )
+
+  def userTokensConfig: UserTokensConfig = app.injector.instanceOf(classOf[UserTokensConfig])
+
+  "POST /auth/login" should {
+    "return the response from a correct user" in withApiClient { client =>
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      val verificationToken = UUID.randomUUID()
+      when(tokenGenerator.next()).thenReturn(verificationToken)
+
+      val user = client.createUser(request).futureValue
+
+      client.verifyEmail(VerifyEmail.Request(UserToken(user.id, verificationToken))).futureValue
+
+      val loginRequest = Login.Request(
+        email = user.email,
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      val loginResponse = client.login(loginRequest).futureValue
+      loginResponse.name must be(user.name)
+      loginResponse.email must be(user.email)
+    }
+
+    "fail when the user tries to login without an email verification" in withApiClient { client =>
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      val user = client.createUser(request).futureValue
+
+      val loginRequest = Login.Request(
+        email = user.email,
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+
+      val error = client
+        .login(loginRequest)
+        .expectError
+
+      error must be("The email is not verified, check your spam folder if you don't see the email.")
+    }
+
+    "fail when the user tries to verify with a wrong token" in withApiClient { client =>
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      val user = client.createUser(request).futureValue
+
+      val verificationToken = UUID.randomUUID()
+      when(tokenGenerator.next()).thenReturn(verificationToken)
+
+      val error = client
+        .verifyEmail(VerifyEmail.Request(UserToken(user.id, verificationToken)))
+        .expectError
+
+      error must be(s"Token for user ${user.id} wasn't found")
+    }
+
+    "fail when the user tries to verify with an expired token" in withApiClient { client =>
+      when(clock.instant()).thenAnswer(Instant.now())
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      val verificationToken = UUID.randomUUID()
+      when(tokenGenerator.next()).thenReturn(verificationToken)
+
+      val user = client.createUser(request).futureValue
+
+      when(clock.instant()).thenAnswer(Instant.now().plus(2, ChronoUnit.DAYS))
+
+      val error = client
+        .verifyEmail(VerifyEmail.Request(UserToken(user.id, verificationToken)))
+        .expectError
+
+      error must be("Token is expired")
+    }
+
+    "login after successful email confirmation" in withApiClient { client =>
+      val email = Email.trusted("test1@email.com")
+      val password = Password.trusted("test123...")
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = email,
+        password = password,
+        captcha = Captcha.trusted("test")
+      )
+      val verificationToken = UUID.randomUUID()
+      when(tokenGenerator.next()).thenReturn(verificationToken)
+
+      val user = client.createUser(request).futureValue
+
+      client.verifyEmail(VerifyEmail.Request(UserToken(user.id, verificationToken))).futureValue
+
+      val response =
+        client.login(Login.Request(email = email, password = password, captcha = Captcha.trusted("test"))).futureValue
+      response.email must be(email)
+      response.token mustNot be(empty)
+    }
+
+    "fail when password is incorrect" in withApiClient { client =>
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      val verificationToken = UUID.randomUUID()
+      when(tokenGenerator.next()).thenReturn(verificationToken)
+
+      val user = client.createUser(request).futureValue
+
+      client.verifyEmail(VerifyEmail.Request(UserToken(user.id, verificationToken))).futureValue
+
+      val loginRequest = Login.Request(
+        email = user.email,
+        password = Password.trusted("Incorrect password"),
+        captcha = Captcha.trusted("test")
+      )
+
+      val error = client
+        .login(loginRequest)
+        .expectError
+
+      error must be("The given email/password doesn't match")
+    }
+
+    "fail when the captcha isn't valid" in withApiClient { client =>
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+      client.createUser(request).futureValue
+
+      val loginRequest = Login.Request(
+        email = Email.trusted("test1@email.com"),
+        password = Password.trusted("test123..."),
+        captcha = Captcha.trusted("test")
+      )
+
+      when(captchaApi.verify(any[Captcha]())).thenReturn(Future.successful(false))
+
+      val error = client
+        .login(loginRequest)
+        .expectError
+
+      error must be("Invalid captcha, try again")
+
+      when(captchaApi.verify(any[Captcha]())).thenReturn(Future.successful(true))
+    }
+
+    "fail when user isn't email confirmed" in withApiClient { client =>
+      val password = Password.trusted("test123...")
+      val request = CreateUser.Request(
+        name = Name.trusted("wiringbits"),
+        email = Email.trusted("test1@email.com"),
+        password = password,
+        captcha = Captcha.trusted("test")
+      )
+      val user = client.createUser(request).futureValue
+
+      val loginRequest = Login.Request(
+        email = user.email,
+        password = password,
+        captcha = Captcha.trusted("test")
+      )
+
+      val error = client
+        .login(loginRequest)
+        .expectError
+
+      error must be("The email is not verified, check your spam folder if you don't see the email.")
+    }
+  }
+}

--- a/web/src/main/scala/net/wiringbits/components/AppSplash.scala
+++ b/web/src/main/scala/net/wiringbits/components/AppSplash.scala
@@ -29,18 +29,15 @@ import scala.util.{Failure, Success}
           .foreach(lang => props.ctx.$lang := lang)
 
         // load authenticated user
-        props.ctx.api.storage.findJwt().filter(_.nonEmpty) match {
-          case Some(jwt) =>
-            props.ctx.api.client.currentUser(jwt).onComplete {
-              case Success(res) =>
-                props.ctx.loggedIn(User(name = res.name, email = res.email, jwt = jwt))
-                setInitialized(true)
+        props.ctx.api.client.currentUser("").onComplete {
+          case Success(res) =>
+            props.ctx.loggedIn(User(name = res.name, email = res.email, jwt = ""))
+            setInitialized(true)
 
-              case Failure(ex) =>
-                ex.printStackTrace()
-                setInitialized(true)
-            }
-          case None =>
+          case Failure(ex) =>
+            println(
+              s"Failed to get current user, we are either unauthenticated or the server had a problem: ${ex.getMessage}"
+            )
             setInitialized(true)
         }
       },

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -54,7 +54,7 @@ import scala.util.{Failure, Success}
               None
             }
         } yield props.ctx.api.client
-          .login(request)
+          .loginBrowser(request)
           .onComplete {
             case Success(res) =>
               setFormData(_.submitted)


### PR DESCRIPTION
Refactor the authentication layer:
- Let's move the auth endpoints to the the new AuthController.
- Implement the browser-logout endpoint which clears the session.
- The browser uses a cookie for authentication which prevents js from accessing the user jwt.