### PR TITLE
Add re-sending the verification email

### DIFF
--- a/lib/common/shared/src/main/scala/net/wiringbits/common/ErrorMessages.scala
+++ b/lib/common/shared/src/main/scala/net/wiringbits/common/ErrorMessages.scala
@@ -1,0 +1,5 @@
+package net.wiringbits.common
+
+object ErrorMessages {
+  def emailNotVerified = "The email is not verified, check your spam folder if you don't see the email."
+}

--- a/lib/common/shared/src/main/scala/net/wiringbits/common/ErrorMessages.scala
+++ b/lib/common/shared/src/main/scala/net/wiringbits/common/ErrorMessages.scala
@@ -1,5 +1,5 @@
 package net.wiringbits.common
 
 object ErrorMessages {
-  def emailNotVerified = "The email is not verified, check your spam folder if you don't see the email."
+  val emailNotVerified = "The email is not verified, check your spam folder if you don't see the email."
 }

--- a/server/src/main/scala/net/wiringbits/validations/ValidateVerifiedUser.scala
+++ b/server/src/main/scala/net/wiringbits/validations/ValidateVerifiedUser.scala
@@ -1,6 +1,6 @@
 package net.wiringbits.validations
 
-import net.wiringbits.common.ErrorMessages.emailNotVerified
+import net.wiringbits.common.ErrorMessages
 import net.wiringbits.repositories.models.User
 
 object ValidateVerifiedUser {
@@ -8,6 +8,6 @@ object ValidateVerifiedUser {
     if (user.verifiedOn.isDefined)
       ()
     else
-      throw new RuntimeException(emailNotVerified)
+      throw new RuntimeException(ErrorMessages.emailNotVerified)
   }
 }

--- a/server/src/main/scala/net/wiringbits/validations/ValidateVerifiedUser.scala
+++ b/server/src/main/scala/net/wiringbits/validations/ValidateVerifiedUser.scala
@@ -1,5 +1,6 @@
 package net.wiringbits.validations
 
+import net.wiringbits.common.ErrorMessages.emailNotVerified
 import net.wiringbits.repositories.models.User
 
 object ValidateVerifiedUser {
@@ -7,6 +8,6 @@ object ValidateVerifiedUser {
     if (user.verifiedOn.isDefined)
       ()
     else
-      throw new RuntimeException("The email is not verified, check your spam folder if you don't see the email.")
+      throw new RuntimeException(emailNotVerified)
   }
 }

--- a/web/src/main/scala/net/wiringbits/AppRouter.scala
+++ b/web/src/main/scala/net/wiringbits/AppRouter.scala
@@ -69,7 +69,18 @@ import scala.util.{Failure, Success}
 
     auth match {
       case AuthState.Unauthenticated =>
-        router.Switch(home, about, signIn, signUp, email, emailCode, forgotPassword, resetPassword, resendVerifyEmail, catchAllRoute)
+        router.Switch(
+          home,
+          about,
+          signIn,
+          signUp,
+          email,
+          emailCode,
+          forgotPassword,
+          resetPassword,
+          resendVerifyEmail,
+          catchAllRoute
+        )
 
       case AuthState.Authenticated(user) =>
         router.Switch(home, me(user), dashboard(user), about, signOut, catchAllRoute)

--- a/web/src/main/scala/net/wiringbits/AppRouter.scala
+++ b/web/src/main/scala/net/wiringbits/AppRouter.scala
@@ -44,6 +44,7 @@ import scala.util.{Failure, Success}
     val emailCode = route("/verify-email/:emailCode", props.ctx)(VerifyEmailWithTokenPage(props.ctx))
     val forgotPassword = route("/forgot-password", props.ctx)(ForgotPasswordPage(props.ctx))
     val resetPassword = route("/reset-password/:resetPasswordCode", props.ctx)(ResetPasswordPage(props.ctx))
+    val resendVerifyEmail = route("/resend-verify-email", props.ctx)(ResendVerifyEmailPage(props.ctx))
 
     def dashboard(user: User) = route("/dashboard", props.ctx)(DashboardPage(props.ctx, user))
     def me(user: User) = route("/me", props.ctx)(UserEditPage(props.ctx, user))
@@ -68,7 +69,7 @@ import scala.util.{Failure, Success}
 
     auth match {
       case AuthState.Unauthenticated =>
-        router.Switch(home, about, signIn, signUp, email, emailCode, forgotPassword, resetPassword, catchAllRoute)
+        router.Switch(home, about, signIn, signUp, email, emailCode, forgotPassword, resetPassword, resendVerifyEmail, catchAllRoute)
 
       case AuthState.Authenticated(user) =>
         router.Switch(home, me(user), dashboard(user), about, signOut, catchAllRoute)

--- a/web/src/main/scala/net/wiringbits/I18nMessages.scala
+++ b/web/src/main/scala/net/wiringbits/I18nMessages.scala
@@ -65,6 +65,7 @@ class I18nMessages(_lang: I18nLang) {
   def emailNotReceived = "If you haven't received the email after a few minutes, please check your spam folder"
   def verifyingEmail = "We're verifing your email"
   def waitAMomentPlease = "Wait a moment, please"
+  def completeTheCaptcha = "Complete the captcha"
 
   def welcome(name: Name): String = {
     s"Welcome ${name.string}"

--- a/web/src/main/scala/net/wiringbits/I18nMessages.scala
+++ b/web/src/main/scala/net/wiringbits/I18nMessages.scala
@@ -48,6 +48,7 @@ class I18nMessages(_lang: I18nLang) {
   def recoverIt = "Recover it"
   def reload = "Reload"
   def logs = "Logs"
+  def resendEmail = "Re-send email"
 
   def aboutPage = "About page"
   def projectDetails = "Add details about the project"

--- a/web/src/main/scala/net/wiringbits/components/pages/ResendVerifyEmailPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/ResendVerifyEmailPage.scala
@@ -1,34 +1,14 @@
 package net.wiringbits.components.pages
 
-import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
-import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
-import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
 import net.wiringbits.AppContext
 import net.wiringbits.components.widgets.ResendVerifyEmailForm
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.Alignment
-import org.scalablytyped.runtime.StringDictionary
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 
 @react object ResendVerifyEmailPage {
   case class Props(ctx: AppContext)
-
-  private lazy val useStyles: StylesHook[Styles[Theme, Unit, String]] = {
-    val stylesCallback: StyleRulesCallback[Theme, Unit, String] = theme =>
-      StringDictionary(
-        "resendVerifyEmailContainer" -> CSSProperties()
-          .setMaxWidth(350)
-          .setWidth("100%")
-      )
-    makeStyles(stylesCallback, WithStylesOptions())
-  }
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     Container(

--- a/web/src/main/scala/net/wiringbits/components/pages/ResendVerifyEmailPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/ResendVerifyEmailPage.scala
@@ -1,0 +1,43 @@
+package net.wiringbits.components.pages
+
+import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
+import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
+import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
+import net.wiringbits.AppContext
+import net.wiringbits.components.widgets.{AppCard, ResendVerifyEmailForm}
+import net.wiringbits.core.I18nHooks
+import net.wiringbits.facades.react.components.Fragment
+import net.wiringbits.ui.components.inputs.EmailInput
+import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{Container, Title}
+import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.Alignment
+import org.scalablytyped.runtime.StringDictionary
+import slinky.core.FunctionalComponent
+import slinky.core.annotations.react
+import slinky.web.html.{className, div}
+
+@react object ResendVerifyEmailPage {
+  case class Props(ctx: AppContext)
+
+  private lazy val useStyles: StylesHook[Styles[Theme, Unit, String]] = {
+    val stylesCallback: StyleRulesCallback[Theme, Unit, String] = theme =>
+      StringDictionary(
+        "resendVerifyEmailContainer" -> CSSProperties()
+          .setMaxWidth(350)
+          .setWidth("100%")
+      )
+    makeStyles(stylesCallback, WithStylesOptions())
+  }
+
+  val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
+    val texts = I18nHooks.useMessages(props.ctx.$lang)
+    val classes = useStyles(())
+
+    Container(
+      flex = Some(1),
+      justifyContent = Alignment.center,
+      alignItems = Alignment.center,
+      child = ResendVerifyEmailForm(props.ctx)
+    )
+  }
+}

--- a/web/src/main/scala/net/wiringbits/components/pages/ResendVerifyEmailPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/ResendVerifyEmailPage.scala
@@ -3,18 +3,19 @@ package net.wiringbits.components.pages
 import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
+  CSSProperties,
+  StyleRulesCallback,
+  Styles,
+  WithStylesOptions
+}
 import net.wiringbits.AppContext
-import net.wiringbits.components.widgets.{AppCard, ResendVerifyEmailForm}
-import net.wiringbits.core.I18nHooks
-import net.wiringbits.facades.react.components.Fragment
-import net.wiringbits.ui.components.inputs.EmailInput
-import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{Container, Title}
+import net.wiringbits.components.widgets.ResendVerifyEmailForm
+import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.Alignment
 import org.scalablytyped.runtime.StringDictionary
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
-import slinky.web.html.{className, div}
 
 @react object ResendVerifyEmailPage {
   case class Props(ctx: AppContext)
@@ -30,9 +31,6 @@ import slinky.web.html.{className, div}
   }
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
-    val texts = I18nHooks.useMessages(props.ctx.$lang)
-    val classes = useStyles(())
-
     Container(
       flex = Some(1),
       justifyContent = Alignment.center,

--- a/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailPage.scala
@@ -2,15 +2,11 @@ package net.wiringbits.components.pages
 
 import com.alexitc.materialui.facade.csstype.mod.{FlexDirectionProperty, TextAlignProperty}
 import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
+import com.alexitc.materialui.facade.materialUiCore.mod.PropTypes.Color
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
 import net.wiringbits.AppContext
 import net.wiringbits.core.I18nHooks
 import org.scalablytyped.runtime.StringDictionary
@@ -18,6 +14,7 @@ import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.Fragment
 import slinky.web.html.{br, className, div}
+import typings.reactRouterDom.{mod => reactRouterDom}
 
 @react object VerifyEmailPage {
   case class Props(ctx: AppContext)
@@ -43,6 +40,7 @@ import slinky.web.html.{br, className, div}
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val texts = I18nHooks.useMessages(props.ctx.$lang)
+    val history = reactRouterDom.useHistory()
     val classes = useStyles(())
 
     Fragment(
@@ -62,7 +60,13 @@ import slinky.web.html.{br, className, div}
             .Typography(
               texts.emailNotReceived
             )
-            .variant(muiStrings.h6)
+            .variant(muiStrings.h6),
+          br(),
+          mui
+            .Button(texts.resendEmail)
+            .variant(muiStrings.contained)
+            .color(Color.primary)
+            .onClick(_ => history.push("/resend-verify-email"))
         )
       )
     )

--- a/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailPage.scala
@@ -6,7 +6,12 @@ import com.alexitc.materialui.facade.materialUiCore.mod.PropTypes.Color
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
+  CSSProperties,
+  StyleRulesCallback,
+  Styles,
+  WithStylesOptions
+}
 import net.wiringbits.AppContext
 import net.wiringbits.core.I18nHooks
 import org.scalablytyped.runtime.StringDictionary

--- a/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
@@ -17,6 +17,7 @@ import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.core.annotations.react
 import slinky.core.facade.Hooks
 import slinky.web.html._
+import typings.reactRouterDom.{mod => reactRouterDom}
 
 import scala.util.{Failure, Success}
 
@@ -25,6 +26,7 @@ import scala.util.{Failure, Success}
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val texts = I18nHooks.useMessages(props.ctx.$lang)
+    val history = reactRouterDom.useHistory()
     val (formData, setFormData) = Hooks.useState(
       StatefulFormData(
         ResendVerifyEmailFormData.initial(
@@ -56,6 +58,7 @@ import scala.util.{Failure, Success}
           .onComplete {
             case Success(_) =>
               setFormData(_.submitted)
+              history.push("/verify-email")
 
             case Failure(ex) =>
               setFormData(_.submissionFailed(ex.getMessage))

--- a/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
@@ -28,6 +28,7 @@ import scala.util.{Failure, Success}
     val (formData, setFormData) = Hooks.useState(
       StatefulFormData(
         ResendVerifyEmailFormData.initial(
+          ResendVerifyEmailFormData.Texts(texts.completeTheCaptcha),
           emailLabel = texts.email
         )
       )

--- a/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
@@ -1,0 +1,130 @@
+package net.wiringbits.components.widgets
+
+import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
+import com.alexitc.materialui.facade.materialUiCore.mod.PropTypes.Color
+import com.alexitc.materialui.facade.react.components.Fragment
+import net.wiringbits.AppContext
+import net.wiringbits.core.I18nHooks
+import net.wiringbits.forms.ResendVerifyEmailFormData
+import net.wiringbits.ui.components.inputs.EmailInput
+import net.wiringbits.webapp.utils.slinkyUtils.components.core.ErrorLabel
+import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container, Title}
+import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.{Alignment, EdgeInsets}
+import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
+import org.scalajs.dom
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
+import slinky.core.{FunctionalComponent, SyntheticEvent}
+import slinky.core.annotations.react
+import slinky.core.facade.Hooks
+import slinky.web.html._
+
+import scala.util.{Failure, Success}
+
+@react object ResendVerifyEmailForm {
+  case class Props(ctx: AppContext)
+
+  val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
+    val texts = I18nHooks.useMessages(props.ctx.$lang)
+    val (formData, setFormData) = Hooks.useState(
+      StatefulFormData(
+        ResendVerifyEmailFormData.initial(
+          emailLabel = texts.email
+        )
+      )
+    )
+
+    def onDataChanged(f: ResendVerifyEmailFormData => ResendVerifyEmailFormData): Unit = {
+      setFormData { current =>
+        current.filling.copy(data = f(current.data))
+      }
+    }
+
+    def handleSubmit(e: SyntheticEvent[_, dom.Event]): Unit = {
+      e.preventDefault()
+
+      if (formData.isSubmitButtonEnabled) {
+        setFormData(_.submit)
+        for {
+          request <- formData.data.submitRequest
+            .orElse {
+              setFormData(_.submissionFailed(texts.completeData))
+              None
+            }
+        } yield props.ctx.api.client
+          .sendEmailVerificationToken(request)
+          .onComplete {
+            case Success(_) =>
+              setFormData(_.submitted)
+
+            case Failure(ex) =>
+              setFormData(_.submissionFailed(ex.getMessage))
+          }
+      } else {
+        println("Submit fired when it is not available")
+      }
+    }
+
+    val emailInput = Container(
+      minWidth = Some("100%"),
+      margin = EdgeInsets.bottom(8),
+      child = EmailInput.component(
+        EmailInput.Props(
+          formData.data.email,
+          disabled = formData.isInputDisabled,
+          onChange = value => onDataChanged(x => x.copy(email = x.email.updated(value)))
+        )
+      )
+    )
+
+    val error = formData.firstValidationError.map { text =>
+      Container(
+        margin = Container.EdgeInsets.top(16),
+        child = ErrorLabel(text)
+      )
+    }
+
+    val recaptcha = ReCaptcha(props.ctx, onChange = captchaOpt => onDataChanged(x => x.copy(captcha = captchaOpt)))
+
+    val resendVerifyEmailButton = {
+      val text =
+        if (formData.isSubmitting) {
+          Fragment(
+            CircularLoader(),
+            Container(margin = EdgeInsets.left(8), child = texts.loading)
+          )
+        } else Fragment(texts.resendEmail)
+
+      mui
+        .Button(text)
+        .fullWidth(true)
+        .disabled(formData.isSubmitButtonDisabled)
+        .variant(muiStrings.contained)
+        .color(Color.primary)
+        .`type`(muiStrings.submit)
+    }
+
+    form(onSubmit := (handleSubmit(_)))(
+      mui
+        .Paper()
+        .elevation(1)(
+          Container(
+            minWidth = Some("300px"),
+            alignItems = Alignment.center,
+            padding = EdgeInsets.all(16),
+            child = Fragment(
+              Title(texts.resendEmail),
+              emailInput,
+              recaptcha,
+              error,
+              Container(
+                minWidth = Some("100%"),
+                margin = EdgeInsets.top(16),
+                alignItems = Alignment.center,
+                child = resendVerifyEmailButton
+              )
+            )
+          )
+        )
+    )
+  }
+}

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -97,10 +97,9 @@ import scala.util.{Failure, Success}
     )
 
     def resendVerifyEmailButton(text: String): ReactElement = {
-      val emailNotVerified = ErrorMessages.emailNotVerified
-
+      // TODO: It would be ideal to match the error against a code than matching a text
       text match {
-        case `emailNotVerified` =>
+        case ErrorMessages.`emailNotVerified` =>
           mui
             .Button(texts.resendEmail)
             .variant(muiStrings.text)

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -96,9 +96,23 @@ import scala.util.{Failure, Success}
     )
 
     val error = formData.firstValidationError.map { text =>
+      val emailNotVerified = "The email is not verified, check your spam folder if you don't see the email."
+
       Container(
+        alignItems = Alignment.center,
         margin = Container.EdgeInsets.top(16),
-        child = ErrorLabel(text)
+        child = Fragment(
+          ErrorLabel(text),
+          text match {
+            case `emailNotVerified` =>
+              mui
+                .Button(texts.resendEmail)
+                .variant(muiStrings.text)
+                .color(muiStrings.primary)
+                .onClick(_ => history.push("/resend-verify-email"))
+            case _ => None
+          }
+        )
       )
     }
 

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -110,13 +110,13 @@ import scala.util.{Failure, Success}
       })
     }
 
-    val error = formData.firstValidationError.map { text =>
+    val error = formData.firstValidationError.map { errorMessage =>
       Container(
         alignItems = Alignment.center,
         margin = Container.EdgeInsets.top(16),
         child = Fragment(
-          ErrorLabel(text),
-          resendVerifyEmailButton(text)
+          ErrorLabel(errorMessage),
+          resendVerifyEmailButton(errorMessage)
         )
       )
     }

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -15,7 +15,7 @@ import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
 import org.scalajs.dom
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
 import slinky.core.annotations.react
-import slinky.core.facade.{Fragment, Hooks}
+import slinky.core.facade.{Fragment, Hooks, ReactElement}
 import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.web.html._
 import typings.reactRouterDom.{mod => reactRouterDom}
@@ -96,18 +96,18 @@ import scala.util.{Failure, Success}
         )
     )
 
-    def resendVerifyEmailButton(text: String) = {
+    def resendVerifyEmailButton(text: String): ReactElement = {
       val emailNotVerified = ErrorMessages.emailNotVerified
 
-      Fragment(text match {
+      text match {
         case `emailNotVerified` =>
           mui
             .Button(texts.resendEmail)
             .variant(muiStrings.text)
             .color(muiStrings.primary)
             .onClick(_ => history.push("/resend-verify-email"))
-        case _ => None
-      })
+        case _ => Fragment()
+      }
     }
 
     val error = formData.firstValidationError.map { errorMessage =>

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -3,6 +3,7 @@ package net.wiringbits.components.widgets
 import com.alexitc.materialui.facade.materialUiCore.mod.PropTypes.Color
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import net.wiringbits.AppContext
+import net.wiringbits.common.ErrorMessages
 import net.wiringbits.core.I18nHooks
 import net.wiringbits.forms.SignInFormData
 import net.wiringbits.models.User
@@ -95,23 +96,27 @@ import scala.util.{Failure, Success}
         )
     )
 
-    val error = formData.firstValidationError.map { text =>
-      val emailNotVerified = "The email is not verified, check your spam folder if you don't see the email."
+    def resendVerifyEmailButton(text: String) = {
+      val emailNotVerified = ErrorMessages.emailNotVerified
 
+      Fragment(text match {
+        case `emailNotVerified` =>
+          mui
+            .Button(texts.resendEmail)
+            .variant(muiStrings.text)
+            .color(muiStrings.primary)
+            .onClick(_ => history.push("/resend-verify-email"))
+        case _ => None
+      })
+    }
+
+    val error = formData.firstValidationError.map { text =>
       Container(
         alignItems = Alignment.center,
         margin = Container.EdgeInsets.top(16),
         child = Fragment(
           ErrorLabel(text),
-          text match {
-            case `emailNotVerified` =>
-              mui
-                .Button(texts.resendEmail)
-                .variant(muiStrings.text)
-                .color(muiStrings.primary)
-                .onClick(_ => history.push("/resend-verify-email"))
-            case _ => None
-          }
+          resendVerifyEmailButton(text)
         )
       )
     }

--- a/web/src/main/scala/net/wiringbits/forms/ForgotPasswordFormData.scala
+++ b/web/src/main/scala/net/wiringbits/forms/ForgotPasswordFormData.scala
@@ -32,6 +32,7 @@ case class ForgotPasswordFormData(
 }
 
 object ForgotPasswordFormData {
+  // TODO: Implement "Complete captcha message" from i18nMessages like ResendVerifyEmailFormData
 
   def initial(
       emailLabel: String

--- a/web/src/main/scala/net/wiringbits/forms/ResendVerifyEmailFormData.scala
+++ b/web/src/main/scala/net/wiringbits/forms/ResendVerifyEmailFormData.scala
@@ -1,0 +1,40 @@
+package net.wiringbits.forms
+
+import net.wiringbits.api.models.SendEmailVerificationToken
+import net.wiringbits.common.models.{Captcha, Email}
+import net.wiringbits.webapp.utils.slinkyUtils.forms.{FormData, FormField}
+
+case class ResendVerifyEmailFormData(
+    email: FormField[Email],
+    captcha: Option[Captcha] = None
+) extends FormData[SendEmailVerificationToken.Request] {
+  override def fields: List[FormField[_]] = List(email)
+
+  override def formValidationErrors: List[String] = {
+    val emptyCaptcha = Option.when(captcha.isEmpty)("Complete the captcha")
+
+    List(
+      fieldsError,
+      emptyCaptcha
+    ).flatten
+  }
+
+  override def submitRequest: Option[SendEmailVerificationToken.Request] = {
+    val formData = this
+    for {
+      email <- formData.email.valueOpt
+      captcha <- formData.captcha
+    } yield SendEmailVerificationToken.Request(
+      email,
+      captcha
+    )
+  }
+}
+
+object ResendVerifyEmailFormData {
+  def initial(
+      emailLabel: String
+  ): ResendVerifyEmailFormData = ResendVerifyEmailFormData(
+    email = new FormField[Email](label = emailLabel, name = "email", required = true, `type` = "email")
+  )
+}

--- a/web/src/main/scala/net/wiringbits/forms/ResendVerifyEmailFormData.scala
+++ b/web/src/main/scala/net/wiringbits/forms/ResendVerifyEmailFormData.scala
@@ -5,13 +5,14 @@ import net.wiringbits.common.models.{Captcha, Email}
 import net.wiringbits.webapp.utils.slinkyUtils.forms.{FormData, FormField}
 
 case class ResendVerifyEmailFormData(
+    texts: ResendVerifyEmailFormData.Texts,
     email: FormField[Email],
     captcha: Option[Captcha] = None
 ) extends FormData[SendEmailVerificationToken.Request] {
   override def fields: List[FormField[_]] = List(email)
 
   override def formValidationErrors: List[String] = {
-    val emptyCaptcha = Option.when(captcha.isEmpty)("Complete the captcha")
+    val emptyCaptcha = Option.when(captcha.isEmpty)(texts.emptyCaptchaError)
 
     List(
       fieldsError,
@@ -32,9 +33,13 @@ case class ResendVerifyEmailFormData(
 }
 
 object ResendVerifyEmailFormData {
+  case class Texts(emptyCaptchaError: String)
+
   def initial(
+      texts: ResendVerifyEmailFormData.Texts,
       emailLabel: String
   ): ResendVerifyEmailFormData = ResendVerifyEmailFormData(
+    texts = texts,
     email = new FormField[Email](label = emailLabel, name = "email", required = true, `type` = "email")
   )
 }

--- a/web/src/main/scala/net/wiringbits/forms/SignInFormData.scala
+++ b/web/src/main/scala/net/wiringbits/forms/SignInFormData.scala
@@ -35,6 +35,7 @@ case class SignInFormData(
 }
 
 object SignInFormData {
+  // TODO: Implement "Complete captcha message" from i18nMessages like ResendVerifyEmailFormData
 
   def initial(
       emailLabel: String,

--- a/web/src/main/scala/net/wiringbits/forms/SignUpFormData.scala
+++ b/web/src/main/scala/net/wiringbits/forms/SignUpFormData.scala
@@ -48,6 +48,7 @@ case class SignUpFormData(
 }
 
 object SignUpFormData {
+  // TODO: Implement "Complete captcha message" from i18nMessages like ResendVerifyEmailFormData
 
   def initial(
       nameLabel: String,

--- a/web/src/test/scala/net/wiringbits/forms/ResendVerifyEmailFormDataSpec.scala
+++ b/web/src/test/scala/net/wiringbits/forms/ResendVerifyEmailFormDataSpec.scala
@@ -1,0 +1,59 @@
+package net.wiringbits.forms
+
+import net.wiringbits.common.models.{Captcha, Email}
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+class ResendVerifyEmailFormDataSpec extends AnyWordSpec {
+  private val initialForm = ResendVerifyEmailFormData.initial(
+    texts = ResendVerifyEmailFormData.Texts("Captcha message"),
+    emailLabel = "Email"
+  )
+
+  private val validForm = initialForm
+    .copy(
+      email = initialForm.email.updated(Email.validate("hello@test.com")),
+      captcha = Some(Captcha.trusted("test"))
+    )
+
+  private val allDataInvalidForm = initialForm
+    .copy(
+      email = initialForm.email.updated(Email.validate("x@")),
+      captcha = None
+    )
+
+  "fields" should {
+    "return the expected fields" in {
+      val expected = List("email")
+      initialForm.fields.map(_.name).toSet must be(expected.toSet)
+    }
+  }
+
+  "formValidationErrors" should {
+    "return no errors when everything mandatory is correct" in {
+      val result = validForm.formValidationErrors
+      result must be(empty)
+    }
+
+    "return all errors" in {
+      allDataInvalidForm.formValidationErrors.size must be(2)
+    }
+  }
+
+  "submitRequest" should {
+
+    "return a request when the emmail is valid" in {
+      val result = validForm.submitRequest
+      result.isDefined must be(true)
+    }
+
+    "return None when the data is not valid" in {
+      val form = validForm
+      val invalidEmail = form.copy(email = allDataInvalidForm.email)
+
+      List(invalidEmail).foreach { form =>
+        form.submitRequest.isDefined must be(false)
+      }
+    }
+  }
+}


### PR DESCRIPTION
New
- ResendVerifyEmail page, form and data form (for /resend-verify-email page)

Changes
- **AppRouter:** Add a route to /resend-verify-email
- **VerifyEmailPage:** Add a button to re-direct to /resend-verify-email
- **SignInPage:** Add a button to re-direct to /resend-verify-email, only appears when the form catches the error "The email is not verified"
- **I18nMessages:** Add re-send email message

## Screenshots
![image](https://user-images.githubusercontent.com/80025691/183523207-db894352-2340-47de-915f-753e413255af.png)
![image](https://user-images.githubusercontent.com/80025691/183523254-ea994daa-057b-450f-88f5-334ce95f316e.png)
![image](https://user-images.githubusercontent.com/80025691/183523288-308ca06f-1b6d-420e-9477-0ec808dc0724.png)
