### PR TITLE
Remove backticks and center snippets

### DIFF
--- a/web/src/main/scala/net/wiringbits/components/pages/HomePage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/HomePage.scala
@@ -110,11 +110,11 @@ import slinky.web.html._
           paragraph(
             Fragment(
               link(texts.tryIt, "https://template-demo-admin.wiringbits.net"),
-              " (user=`",
+              " (user=",
               strong("demo"),
-              "`, password=`",
+              ", password=",
               strong("wiringbits"),
-              "`)"
+              ")"
             )
           )
         )

--- a/web/src/main/scala/net/wiringbits/components/pages/HomePage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/HomePage.scala
@@ -36,7 +36,8 @@ import slinky.web.html._
         "snippet" -> CSSProperties()
           .setMaxWidth(800)
           .setWidth("100%")
-          .setMargin("1em 0"),
+          .setDisplay("block")
+          .setMargin("1em auto"),
         "screenshot" -> CSSProperties()
           .setMaxWidth(1200)
           .setWidth("100%")


### PR DESCRIPTION
Removing backticks in user and password and center snippets in Home Page

## Screenshots
![image](https://user-images.githubusercontent.com/80025691/188971193-cbb51b82-8a7e-4e57-9211-74b1ed9c32c0.png)
![image](https://user-images.githubusercontent.com/80025691/188971236-75cf3748-c685-4afb-ac1a-7ed661d23671.png)
