### PR TITLE
Email flow improvements

### DIFF
--- a/docs/setup-dev-environment.md
+++ b/docs/setup-dev-environment.md
@@ -129,6 +129,9 @@ Update application.conf to set your environment specific values (just avoid comm
    
    # emails
    export EMAIL_SENDER_ADDRESS="test@wiringbits.net"
+   export EMAIL_PROVIDER=none
+
+   # aws, required only if the email provider is AWS
    export AWS_REGION="us-west-2"
    export AWS_ACCESS_KEY_ID="REPLACE_ME"
    export AWS_SECRET_ACCESS_KEY="REPLACE_ME"
@@ -142,9 +145,12 @@ Time to run the app:
 2. `sbt dev-web` launches the main web app at `localhost:8080` 
 3. `sbt dev-admin` launches the admin web app at `localhost:8081`
 
-**Hint** All these apps are automatically reloaded on code changes.
-**Hint 2**: The server app prints the settings after starting, double check that they match your custom settings.
 
+**Hints**:
+
+- All these apps are automatically reloaded on code changes.
+- The server app prints the settings after starting, double check that they match your custom settings.
+- By default, outgoing emails are logged, be sure to check those to look for the email verification links.
 
 ## Test dependencies
 
@@ -163,5 +169,4 @@ Commands:
 
 ## Deployment setup
 
-Check the [infra](./infra/README.md) project.
-
+Check the [infra](../infra/README.md) project.

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -125,6 +125,10 @@ play.modules.enabled += "net.wiringbits.webapp.utils.admin.modules.ExecutorsModu
 email {
   senderAddress = "replace@replace.net"
   senderAddress = ${?EMAIL_SENDER_ADDRESS}
+
+  # defines the provider used to send emails, valid values being "aws" or "none"
+  provider = "none"
+  provider = ${?EMAIL_PROVIDER}
 }
 
 userTokens {

--- a/server/src/main/scala/net/wiringbits/actions/ForgotPasswordAction.scala
+++ b/server/src/main/scala/net/wiringbits/actions/ForgotPasswordAction.scala
@@ -1,32 +1,20 @@
 package net.wiringbits.actions
 
 import net.wiringbits.api.models.ForgotPassword
-import net.wiringbits.apis.{EmailApi, ReCaptchaApi}
-import net.wiringbits.apis.models.EmailRequest
-import net.wiringbits.config.{UserTokensConfig, WebAppConfig}
-import net.wiringbits.repositories.models.{User, UserToken, UserTokenType}
-import net.wiringbits.repositories.{UserTokensRepository, UsersRepository}
-import net.wiringbits.util.{EmailMessage, TokenGenerator, TokensHelper}
+import net.wiringbits.apis.ReCaptchaApi
+import net.wiringbits.repositories.UsersRepository
+import net.wiringbits.repositories.models.User
+import net.wiringbits.util.EmailsHelper
 import net.wiringbits.validations.{ValidateCaptcha, ValidateVerifiedUser}
 
-import java.time.temporal.ChronoUnit
-import java.time.{Clock, Instant}
-import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ForgotPasswordAction @Inject() (
-    userTokensConfig: UserTokensConfig,
-    webAppConfig: WebAppConfig,
     captchaApi: ReCaptchaApi,
     usersRepository: UsersRepository,
-    emailApi: EmailApi,
-    userTokensRepository: UserTokensRepository,
-    tokenGenerator: TokenGenerator
-)(implicit
-    ec: ExecutionContext,
-    clock: Clock
-) {
+    emailsHelper: EmailsHelper
+)(implicit ec: ExecutionContext) {
   def apply(request: ForgotPassword.Request): Future[ForgotPassword.Response] = {
     for {
       _ <- ValidateCaptcha(captchaApi, request.captcha)
@@ -38,23 +26,9 @@ class ForgotPasswordAction @Inject() (
   }
 
   private def whenExists(user: User) = {
-    val token = tokenGenerator.next()
-    val hmacToken = TokensHelper.doHMACSHA1(token.toString.getBytes, userTokensConfig.hmacSecret)
-    val createToken = UserToken
-      .Create(
-        id = UUID.randomUUID(),
-        token = hmacToken,
-        tokenType = UserTokenType.ResetPassword,
-        createdAt = Instant.now(clock),
-        userId = user.id,
-        expiresAt = Instant.now(clock).plus(userTokensConfig.resetPasswordExp.toHours, ChronoUnit.HOURS)
-      )
-
-    ValidateVerifiedUser(user)
-    val emailMessage = EmailMessage.forgotPassword(user.name, webAppConfig.host, s"${user.id}_$token")
     for {
-      _ <- userTokensRepository.create(createToken)
-      _ <- emailApi.sendEmail(EmailRequest(user.email, emailMessage))
+      _ <- Future { ValidateVerifiedUser(user) }
+      _ <- emailsHelper.sendPasswordRecoveryEmail(user)
     } yield ()
   }
 }

--- a/server/src/main/scala/net/wiringbits/actions/SendEmailVerificationTokenAction.scala
+++ b/server/src/main/scala/net/wiringbits/actions/SendEmailVerificationTokenAction.scala
@@ -1,33 +1,19 @@
 package net.wiringbits.actions
 
-import net.wiringbits.apis.models.EmailRequest
-import net.wiringbits.apis.{EmailApi, ReCaptchaApi}
-import net.wiringbits.config.{UserTokensConfig, WebAppConfig}
+import net.wiringbits.api.models.SendEmailVerificationToken
+import net.wiringbits.apis.ReCaptchaApi
 import net.wiringbits.repositories.UsersRepository
-import net.wiringbits.util.{EmailMessage, TokenGenerator, TokensHelper}
+import net.wiringbits.util.EmailsHelper
 import net.wiringbits.validations.{ValidateCaptcha, ValidateEmailIsRegistered, ValidateUserIsNotVerified}
-import net.wiringbits.repositories.models.{UserToken, UserTokenType}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import net.wiringbits.api.models.SendEmailVerificationToken
-import net.wiringbits.repositories.UserTokensRepository
-import java.time.temporal.ChronoUnit
-import java.time.{Clock, Instant}
-import java.util.UUID
 
 class SendEmailVerificationTokenAction @Inject() (
     usersRepository: UsersRepository,
-    tokenGenerator: TokenGenerator,
-    userTokensConfig: UserTokensConfig,
-    userTokensRepository: UserTokensRepository,
-    webAppConfig: WebAppConfig,
-    emailApi: EmailApi,
+    emailsHelper: EmailsHelper,
     reCaptchaApi: ReCaptchaApi
-)(implicit
-    ec: ExecutionContext,
-    clock: Clock
-) {
+)(implicit ec: ExecutionContext) {
 
   def apply(request: SendEmailVerificationToken.Request): Future[SendEmailVerificationToken.Response] = {
     for {
@@ -36,28 +22,8 @@ class SendEmailVerificationTokenAction @Inject() (
       user = userMaybe.getOrElse(throw new RuntimeException(s"User with email ${request.email} wasn't found"))
       _ = ValidateUserIsNotVerified(user)
 
-      token = tokenGenerator.next()
-      hmacToken = TokensHelper.doHMACSHA1(token.toString.getBytes(), userTokensConfig.hmacSecret)
-
-      createToken = UserToken
-        .Create(
-          id = UUID.randomUUID(),
-          token = hmacToken,
-          tokenType = UserTokenType.EmailVerification,
-          createdAt = Instant.now(clock),
-          userId = user.id,
-          expiresAt = Instant.now(clock).plus(userTokensConfig.emailVerificationExp.toSeconds, ChronoUnit.SECONDS)
-        )
-      _ <- userTokensRepository.create(createToken)
-
-      emailParameter = s"${user.id}_$token"
-      emailMessage = EmailMessage.registration(
-        name = user.name,
-        url = webAppConfig.host,
-        emailParameter = emailParameter
-      )
-      _ <- emailApi.sendEmail(EmailRequest(request.email, emailMessage))
-    } yield SendEmailVerificationToken.Response(expiresAt = createToken.expiresAt)
+      expiresAt <- emailsHelper.sendEmailVerificationToken(user)
+    } yield SendEmailVerificationToken.Response(expiresAt = expiresAt)
   }
 
   private def validations(request: SendEmailVerificationToken.Request) = {

--- a/server/src/main/scala/net/wiringbits/apis/EmailApi.scala
+++ b/server/src/main/scala/net/wiringbits/apis/EmailApi.scala
@@ -1,9 +1,23 @@
 package net.wiringbits.apis
 
 import net.wiringbits.apis.models.EmailRequest
+import org.slf4j.LoggerFactory
 
-import scala.concurrent.Future
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
 trait EmailApi {
   def sendEmail(emailRequest: EmailRequest): Future[Unit]
+}
+
+object EmailApi {
+  class LogImpl @Inject() (implicit ec: ExecutionContext) extends EmailApi {
+    private val logger = LoggerFactory.getLogger(this.getClass)
+
+    override def sendEmail(request: EmailRequest): Future[Unit] = Future {
+      logger.info(
+        s"Sending email, to = ${request.destination}, subject = ${request.message.subject}, body = ${request.message.body}"
+      )
+    }
+  }
 }

--- a/server/src/main/scala/net/wiringbits/config/EmailConfig.scala
+++ b/server/src/main/scala/net/wiringbits/config/EmailConfig.scala
@@ -2,15 +2,16 @@ package net.wiringbits.config
 
 import play.api.Configuration
 
-case class EmailConfig(senderAddress: String) {
+case class EmailConfig(senderAddress: String, provider: String) {
   override def toString: String = {
-    s"EmailConfig(senderAddress = $senderAddress)"
+    s"EmailConfig(senderAddress = $senderAddress, provider = $provider)"
   }
 }
 
 object EmailConfig {
   def apply(config: Configuration): EmailConfig = {
     val senderAddress = config.get[String]("senderAddress")
-    EmailConfig(senderAddress)
+    val provider = config.get[String]("provider")
+    new EmailConfig(senderAddress = senderAddress, provider = provider)
   }
 }

--- a/server/src/main/scala/net/wiringbits/modules/ApisModule.scala
+++ b/server/src/main/scala/net/wiringbits/modules/ApisModule.scala
@@ -1,10 +1,35 @@
 package net.wiringbits.modules
 
-import com.google.inject.AbstractModule
+import com.google.inject.{AbstractModule, Provider}
 import net.wiringbits.apis.{EmailApi, EmailApiAWSImpl}
+import net.wiringbits.config.EmailConfig
+import org.slf4j.LoggerFactory
+
+import javax.inject.Inject
 
 class ApisModule extends AbstractModule {
   override def configure(): Unit = {
-    val _ = bind(classOf[EmailApi]).to(classOf[EmailApiAWSImpl])
+    val _ = bind(classOf[EmailApi])
+      .toProvider(classOf[ApisModule.EmailApiProvider])
+      .asEagerSingleton()
+  }
+}
+
+object ApisModule {
+
+  class EmailApiProvider @Inject() (config: EmailConfig, logImpl: EmailApi.LogImpl, awsImpl: EmailApiAWSImpl)
+      extends Provider[EmailApi] {
+
+    private val logger = LoggerFactory.getLogger(this.getClass)
+
+    override def get(): EmailApi = {
+      if (config.provider equalsIgnoreCase "aws") {
+        logger.info("Mail provider set to AWS")
+        awsImpl
+      } else {
+        logger.info("Mail provider set to none, emails will be printed as logs")
+        logImpl
+      }
+    }
   }
 }

--- a/server/src/main/scala/net/wiringbits/util/EmailsHelper.scala
+++ b/server/src/main/scala/net/wiringbits/util/EmailsHelper.scala
@@ -1,0 +1,79 @@
+package net.wiringbits.util
+
+import net.wiringbits.apis.EmailApi
+import net.wiringbits.apis.models.EmailRequest
+import net.wiringbits.config.{UserTokensConfig, WebAppConfig}
+import net.wiringbits.repositories.UserTokensRepository
+import net.wiringbits.repositories.models.{User, UserToken, UserTokenType}
+
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant}
+import java.util.UUID
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class EmailsHelper @Inject() (
+    emailApi: EmailApi,
+    webAppConfig: WebAppConfig,
+    userTokensRepository: UserTokensRepository,
+    tokenGenerator: TokenGenerator,
+    userTokensConfig: UserTokensConfig,
+    clock: Clock
+)(implicit ec: ExecutionContext) {
+
+  def sendEmailVerificationToken(user: User): Future[Instant] = {
+    // we can't retrieve the plain text token, hence, we generate another one
+    val token = tokenGenerator.next()
+    val hmacToken = TokensHelper.doHMACSHA1(token.toString.getBytes(), userTokensConfig.hmacSecret)
+
+    val createToken = UserToken
+      .Create(
+        id = UUID.randomUUID(),
+        token = hmacToken,
+        tokenType = UserTokenType.EmailVerification,
+        createdAt = Instant.now(clock),
+        userId = user.id,
+        expiresAt = Instant.now(clock).plus(userTokensConfig.emailVerificationExp.toSeconds, ChronoUnit.SECONDS)
+      )
+
+    for {
+      _ <- userTokensRepository.create(createToken)
+      _ <- sendRegistrationEmailWithVerificationToken(user, token)
+    } yield createToken.expiresAt
+  }
+
+  // we don't save emails in the queue when user tokens are involved
+  def sendRegistrationEmailWithVerificationToken(user: User, token: UUID): Future[Unit] = {
+    val emailParameter = s"${user.id}_$token"
+    val emailMessage = EmailMessage.registration(
+      name = user.name,
+      url = webAppConfig.host,
+      emailParameter = emailParameter
+    )
+
+    val request = EmailRequest(user.email, emailMessage)
+    emailApi.sendEmail(request)
+  }
+
+  // we don't save emails in the queue when user tokens are involved
+  def sendPasswordRecoveryEmail(user: User): Future[Unit] = {
+    val token = tokenGenerator.next()
+    val emailParameter = s"${user.id}_$token"
+    val hmacToken = TokensHelper.doHMACSHA1(token.toString.getBytes, userTokensConfig.hmacSecret)
+    val createToken = UserToken
+      .Create(
+        id = UUID.randomUUID(),
+        token = hmacToken,
+        tokenType = UserTokenType.ResetPassword,
+        createdAt = Instant.now(clock),
+        userId = user.id,
+        expiresAt = Instant.now(clock).plus(userTokensConfig.resetPasswordExp.toHours, ChronoUnit.HOURS)
+      )
+    val message = EmailMessage.forgotPassword(user.name, webAppConfig.host, emailParameter)
+
+    for {
+      _ <- userTokensRepository.create(createToken)
+      _ <- emailApi.sendEmail(EmailRequest(user.email, message))
+    } yield ()
+  }
+}


### PR DESCRIPTION
Let's simplify how to deal with emails when not using AWS, by default, we now have a dummy implementation that logs outgoing emails.

This removes the AWS SES requirement for trying the project.

Also, do minor refactors to the flows that send emails without the background job, clarifying with comments that this is done because these emails include user tokens which should not touch our database.