### PR TITLE
Use akka-streams to stream pending email notifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val playJson = "2.9.2"
 val sttp = "3.8.3"
 val webappUtils = "0.5.14"
 val swagger = "1.6.6"
+val anorm = "2.6.10"
 
 val consoleDisabledOptions = Seq("-Werror", "-Ywarn-unused", "-Ywarn-unused-import")
 
@@ -327,7 +328,8 @@ lazy val server = (project in file("server"))
     fork := true,
     Test / fork := true, // allows for graceful shutdown of containers once the tests have finished running
     libraryDependencies ++= Seq(
-      "org.playframework.anorm" %% "anorm" % "2.6.10",
+      "org.playframework.anorm" %% "anorm" % anorm,
+      "org.playframework.anorm" %% "anorm-akka" % anorm,
       "com.typesafe.play" %% "play-json" % "2.9.2",
       "org.postgresql" % "postgresql" % "42.3.6",
       "de.svenkubiak" % "jBCrypt" % "0.4.3",

--- a/server/src/main/scala/net/wiringbits/actions/internal/GetPendingNotificationsAction.scala
+++ b/server/src/main/scala/net/wiringbits/actions/internal/GetPendingNotificationsAction.scala
@@ -7,7 +7,7 @@ import javax.inject.Inject
 import scala.concurrent.Future
 
 class GetPendingNotificationsAction @Inject() (userNotificationsRepository: UserNotificationsRepository) {
-  def apply(): Future[List[UserNotification]] = {
-    userNotificationsRepository.getPendingNotifications
+  def apply(): Future[akka.stream.scaladsl.Source[UserNotification, Future[Int]]] = {
+    userNotificationsRepository.streamPendingNotifications
   }
 }

--- a/server/src/main/scala/net/wiringbits/actions/internal/StreamPendingNotificationsAction.scala
+++ b/server/src/main/scala/net/wiringbits/actions/internal/StreamPendingNotificationsAction.scala
@@ -6,7 +6,7 @@ import net.wiringbits.repositories.models.UserNotification
 import javax.inject.Inject
 import scala.concurrent.Future
 
-class GetPendingNotificationsAction @Inject() (userNotificationsRepository: UserNotificationsRepository) {
+class StreamPendingNotificationsAction @Inject() (userNotificationsRepository: UserNotificationsRepository) {
   def apply(): Future[akka.stream.scaladsl.Source[UserNotification, Future[Int]]] = {
     userNotificationsRepository.streamPendingNotifications
   }

--- a/server/src/main/scala/net/wiringbits/repositories/UserNotificationsRepository.scala
+++ b/server/src/main/scala/net/wiringbits/repositories/UserNotificationsRepository.scala
@@ -9,11 +9,23 @@ import java.time.{Clock, Instant}
 import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 class UserNotificationsRepository @Inject() (database: Database)(implicit ec: DatabaseExecutionContext, clock: Clock) {
-  def getPendingNotifications: Future[List[UserNotification]] = Future {
-    database.withConnection { implicit conn =>
-      UserNotificationsDAO.getPendingNotifications()
+  def streamPendingNotifications: Future[akka.stream.scaladsl.Source[UserNotification, Future[Int]]] = Future {
+    implicit val conn = database.getConnection() // TODO: Consider using a different connection pool
+    try {
+      val stream = UserNotificationsDAO.streamPendingNotifications()
+      // make sure to close the connection when it isn't required anymore
+      stream.mapMaterializedValue(_.onComplete { _ =>
+        conn.close()
+      })
+
+      stream
+    } catch {
+      case NonFatal(ex) =>
+        conn.close()
+        throw new RuntimeException("Failed to stream pending notifications, this isn't expected at all", ex)
     }
   }
 


### PR DESCRIPTION
The goal is to manage better the way that email notifications are submitted, with akka-streams, we can stream all the pending notifications and define throttling rules to avoid overloading the app with this task.