### PR TITLE
Add caching for sbt dependencies and build artifacts (Issue #342)

### DIFF
--- a/.github/workflows/codepreview.yml
+++ b/.github/workflows/codepreview.yml
@@ -36,6 +36,27 @@ jobs:
         with:
           java-version: 'adopt:1.11.0-11'
           node-version: '16.7.0'
+          
+      - name: Cache sbt dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+      - name: Cache sbt build artifacts
+        uses: actions/cache@v2
+        with:
+          path: |
+            admin/target/scala-*
+            web/target/scala-*
+            server/target/universal/
+          key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-
 
       - name: Compile
         run: sbt compile

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,28 @@ jobs:
           java-version: 'adopt:1.11.0-11'
           node-version: '16.7.0'
 
+      - name: Cache sbt dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+
+      - name: Cache sbt build artifacts
+        uses: actions/cache@v2
+        with:
+          path: |
+            admin/target/scala-*
+            web/target/scala-*
+            server/target/universal/
+          key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            
       - name: Check code format
         run: sbt scalafmtCheckAll
 


### PR DESCRIPTION
(Issue #342  )
This pull request adds caching steps to the CI workflow to reduce the time and bandwidth needed for each job. It uses the actions/cache@v2 action to cache the sbt dependencies and build artifacts based on the hash of the sbt files and the operating system. This can improve the performance and reliability of the CI workflow.
