### PR TITLE
Udate webapp-utils to v0.6.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 

--- a/server/src/main/scala/net/wiringbits/modules/DataExplorerModule.scala
+++ b/server/src/main/scala/net/wiringbits/modules/DataExplorerModule.scala
@@ -6,7 +6,11 @@ import net.wiringbits.webapp.utils.admin.config.{DataExplorerSettings, TableSett
 class DataExplorerModule extends AbstractModule {
 
   @Provides()
-  def dataExplorerSettings: DataExplorerSettings = DataExplorerSettings(settings)
+  def dataExplorerSettings: DataExplorerSettings = DataExplorerSettings(baseUrl, settings)
+
+  val baseUrl = net.wiringbits.BuildInfo.apiUrl.filter(_.nonEmpty).getOrElse {
+    "http://localhost:9000"
+  }
 
   val settings = List(
     TableSettings(

--- a/web/src/main/scala/net/wiringbits/App.scala
+++ b/web/src/main/scala/net/wiringbits/App.scala
@@ -3,9 +3,9 @@ package net.wiringbits
 import com.alexitc.materialui.facade.materialUiCore.{components => mui}
 import com.alexitc.materialui.facade.materialUiStyles.components.ThemeProvider
 import net.wiringbits.components.AppSplash
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.BrowserRouter
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
-import typings.reactRouterDom.{components => router}
 
 @react object App {
   case class Props(ctx: AppContext)
@@ -16,7 +16,7 @@ import typings.reactRouterDom.{components => router}
     ThemeProvider(AppTheme.value)(
       mui.MuiThemeProvider(AppTheme.value)(
         mui.CssBaseline(),
-        router.BrowserRouter.basename("")(
+        BrowserRouter(basename = "/")(
           AppSplash(props.ctx, appRouter)
         )
       )

--- a/web/src/main/scala/net/wiringbits/AppRouter.scala
+++ b/web/src/main/scala/net/wiringbits/AppRouter.scala
@@ -5,30 +5,23 @@ import net.wiringbits.components.widgets.{AppBar, Footer}
 import net.wiringbits.core.ReactiveHooks
 import net.wiringbits.models.{AuthState, User}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Scaffold
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.{Redirect, Route, Switch}
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.ReactElement
-import typings.reactRouter.mod.RouteProps
-import typings.reactRouterDom.components.Route
-import typings.reactRouterDom.{components => router}
 
 import scala.util.{Failure, Success}
 
 @react object AppRouter {
   case class Props(ctx: AppContext)
 
-  private def route(path: String, ctx: AppContext)(child: => ReactElement): Route.Builder[RouteProps] = {
-    router.Route(
-      RouteProps()
-        .setExact(true)
-        .setPath(path)
-        .setRender { route =>
-          Scaffold(
-            appbar = Some(AppBar(ctx)),
-            body = child,
-            footer = Some(Footer(ctx))
-          )
-        }
+  private def route(path: String, ctx: AppContext)(child: => ReactElement): ReactElement = {
+    Route(path = path, exact = true)(
+      Scaffold(
+        appbar = Some(AppBar(ctx)),
+        body = child,
+        footer = Some(Footer(ctx))
+      )
     )
   }
 
@@ -58,18 +51,14 @@ import scala.util.{Failure, Success}
           println(s"Failed to log out: ${exception.getMessage}")
       }
 
-      router.Redirect("/")
+      Redirect("/")
     }
 
-    val catchAllRoute = router.Route(
-      RouteProps().setRender { _ =>
-        router.Redirect("/")
-      }
-    )
+    val catchAllRoute = Route(path = "*")(render = Redirect("/"))
 
     auth match {
       case AuthState.Unauthenticated =>
-        router.Switch(
+        Switch(
           home,
           about,
           signIn,
@@ -83,7 +72,7 @@ import scala.util.{Failure, Success}
         )
 
       case AuthState.Authenticated(user) =>
-        router.Switch(home, me(user), dashboard(user), about, signOut, catchAllRoute)
+        Switch(home, me(user), dashboard(user), about, signOut, catchAllRoute)
     }
   }
 }

--- a/web/src/main/scala/net/wiringbits/components/pages/ForgotPasswordPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/ForgotPasswordPage.scala
@@ -4,23 +4,18 @@ import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
 import net.wiringbits.components.widgets.{AppCard, ForgotPasswordForm}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.Alignment
 import net.wiringbits.AppContext
 import net.wiringbits.core.I18nHooks
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.useHistory
 import org.scalablytyped.runtime.StringDictionary
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.Fragment
 import slinky.web.html.{className, div}
-import typings.reactRouterDom.mod.useHistory
 
 @react object ForgotPasswordPage {
   case class Props(ctx: AppContext)

--- a/web/src/main/scala/net/wiringbits/components/pages/ResetPasswordPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/ResetPasswordPage.scala
@@ -37,7 +37,7 @@ import scala.scalajs.js
     val texts = I18nHooks.useMessages(props.ctx.$lang)
     val history = useHistory()
     val params = useParams()
-    val resetPasswordCode = params("resetPasswordCode")
+    val resetPasswordCode = params.get("resetPasswordCode").getOrElse("")
     val userToken = UserToken.validate(resetPasswordCode)
 
     Container(

--- a/web/src/main/scala/net/wiringbits/components/pages/ResetPasswordPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/ResetPasswordPage.scala
@@ -4,23 +4,18 @@ import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
 import net.wiringbits.common.models.UserToken
 import net.wiringbits.components.widgets.{AppCard, ResetPasswordForm}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container
 import net.wiringbits.AppContext
 import net.wiringbits.core.I18nHooks
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.{useHistory, useParams}
 import org.scalablytyped.runtime.StringDictionary
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.Fragment
 import slinky.web.html.{className, div}
-import typings.reactRouter.mod.{useHistory, useParams}
 
 import scala.scalajs.js
 
@@ -42,7 +37,7 @@ import scala.scalajs.js
     val texts = I18nHooks.useMessages(props.ctx.$lang)
     val history = useHistory()
     val params = useParams()
-    val resetPasswordCode = params.asInstanceOf[js.Dynamic].resetPasswordCode.toString
+    val resetPasswordCode = params("resetPasswordCode")
     val userToken = UserToken.validate(resetPasswordCode)
 
     Container(

--- a/web/src/main/scala/net/wiringbits/components/pages/SignInPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/SignInPage.scala
@@ -4,23 +4,18 @@ import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
 import net.wiringbits.components.widgets._
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.{Alignment, EdgeInsets}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{Container, Title}
 import net.wiringbits.AppContext
 import net.wiringbits.core.I18nHooks
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.useHistory
 import org.scalablytyped.runtime.StringDictionary
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.Fragment
 import slinky.web.html.{className, div}
-import typings.reactRouterDom.mod.useHistory
 
 @react object SignInPage {
   case class Props(ctx: AppContext)

--- a/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailPage.scala
@@ -6,22 +6,16 @@ import com.alexitc.materialui.facade.materialUiCore.mod.PropTypes.Color
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
 import net.wiringbits.AppContext
 import net.wiringbits.core.I18nHooks
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.{useHistory, useLocation}
 import org.scalablytyped.runtime.StringDictionary
 import org.scalajs.dom.URLSearchParams
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.Fragment
 import slinky.web.html.{br, className, div}
-import typings.reactRouterDom.mod.useLocation
-import typings.reactRouterDom.{mod => reactRouterDom}
 
 @react object VerifyEmailPage {
   case class Props(ctx: AppContext)
@@ -47,7 +41,7 @@ import typings.reactRouterDom.{mod => reactRouterDom}
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val texts = I18nHooks.useMessages(props.ctx.$lang)
-    val history = reactRouterDom.useHistory()
+    val history = useHistory()
     val params = new URLSearchParams(useLocation().search)
     val emailParam = Option(params.get("email")).getOrElse("")
     val classes = useStyles(())

--- a/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailWithTokenPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailWithTokenPage.scala
@@ -66,7 +66,7 @@ import scala.util.{Failure, Success}
     val history = useHistory()
     val params = useParams()
     val (state, setState) = Hooks.useState(initialState)
-    val emailCodeOpt = UserToken.validate(params("emailCode"))
+    val emailCodeOpt = UserToken.validate(params.get("emailCode").getOrElse(""))
 
     def sendEmailCode(): Unit = {
       setState(_.copy(loading = true))

--- a/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailWithTokenPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailWithTokenPage.scala
@@ -67,7 +67,6 @@ import scala.util.{Failure, Success}
     val params = useParams()
     val (state, setState) = Hooks.useState(initialState)
     val emailCodeOpt = UserToken.validate(params("emailCode"))
-    params("emailCode")
 
     def sendEmailCode(): Unit = {
       setState(_.copy(loading = true))

--- a/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailWithTokenPage.scala
+++ b/web/src/main/scala/net/wiringbits/components/pages/VerifyEmailWithTokenPage.scala
@@ -5,24 +5,19 @@ import com.alexitc.materialui.facade.materialUiCore.createMuiThemeMod.Theme
 import com.alexitc.materialui.facade.materialUiCore.{components => mui, materialUiCoreStrings => muiStrings}
 import com.alexitc.materialui.facade.materialUiStyles.makeStylesMod.StylesHook
 import com.alexitc.materialui.facade.materialUiStyles.mod.makeStyles
-import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{
-  CSSProperties,
-  StyleRulesCallback,
-  Styles,
-  WithStylesOptions
-}
+import com.alexitc.materialui.facade.materialUiStyles.withStylesMod.{CSSProperties, StyleRulesCallback, Styles, WithStylesOptions}
 import net.wiringbits.api.models.VerifyEmail
 import net.wiringbits.common.models.UserToken
 import net.wiringbits.core.I18nHooks
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container}
 import net.wiringbits.AppContext
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.{useHistory, useParams}
 import org.scalablytyped.runtime.StringDictionary
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 import slinky.core.FunctionalComponent
 import slinky.core.annotations.react
 import slinky.core.facade.{Fragment, Hooks}
 import slinky.web.html.{className, div}
-import typings.reactRouterDom.mod.{useHistory, useParams}
 
 import scala.scalajs.js
 import scala.scalajs.js.timers.setTimeout
@@ -71,7 +66,8 @@ import scala.util.{Failure, Success}
     val history = useHistory()
     val params = useParams()
     val (state, setState) = Hooks.useState(initialState)
-    val emailCodeOpt = UserToken.validate(params.asInstanceOf[js.Dynamic].emailCode.toString)
+    val emailCodeOpt = UserToken.validate(params("emailCode"))
+    params("emailCode")
 
     def sendEmailCode(): Unit = {
       setState(_.copy(loading = true))

--- a/web/src/main/scala/net/wiringbits/components/widgets/ForgotPasswordForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/ForgotPasswordForm.scala
@@ -7,6 +7,7 @@ import net.wiringbits.forms.ForgotPasswordFormData
 import net.wiringbits.ui.components.inputs.EmailInput
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.ErrorLabel
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container}
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.useHistory
 import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
 import org.scalajs.dom
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
@@ -14,7 +15,6 @@ import slinky.core.annotations.react
 import slinky.core.facade.{Fragment, Hooks}
 import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.web.html.{form, onSubmit}
-import typings.reactRouter.mod.useHistory
 
 import scala.util.{Failure, Success}
 

--- a/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/ResendVerifyEmailForm.scala
@@ -11,6 +11,7 @@ import net.wiringbits.ui.components.inputs.EmailInput
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.ErrorLabel
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container, Title}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.{Alignment, EdgeInsets}
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.{useHistory, useLocation}
 import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
 import org.scalajs.dom
 import org.scalajs.dom.URLSearchParams
@@ -19,8 +20,6 @@ import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.core.annotations.react
 import slinky.core.facade.Hooks
 import slinky.web.html._
-import typings.reactRouterDom.mod.useLocation
-import typings.reactRouterDom.{mod => reactRouterDom}
 
 import scala.util.{Failure, Success}
 
@@ -29,7 +28,7 @@ import scala.util.{Failure, Success}
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val texts = I18nHooks.useMessages(props.ctx.$lang)
-    val history = reactRouterDom.useHistory()
+    val history = useHistory()
     val params = new URLSearchParams(useLocation().search)
     val emailParam = Option(params.get("email")).getOrElse("")
     val (formData, setFormData) = Hooks.useState(

--- a/web/src/main/scala/net/wiringbits/components/widgets/ResetPasswordForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/ResetPasswordForm.scala
@@ -9,6 +9,7 @@ import net.wiringbits.models.User
 import net.wiringbits.ui.components.inputs.PasswordInput
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.ErrorLabel
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container}
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.useHistory
 import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
 import org.scalajs.dom
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
@@ -16,7 +17,6 @@ import slinky.core.annotations.react
 import slinky.core.facade.{Fragment, Hooks}
 import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.web.html.{form, onSubmit}
-import typings.reactRouter.mod.useHistory
 
 import scala.util.{Failure, Success}
 

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignInForm.scala
@@ -11,6 +11,7 @@ import net.wiringbits.ui.components.inputs.{EmailInput, PasswordInput}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.ErrorLabel
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container.{Alignment, EdgeInsets}
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container}
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.useHistory
 import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
 import org.scalajs.dom
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits._
@@ -18,7 +19,6 @@ import slinky.core.annotations.react
 import slinky.core.facade.{Fragment, Hooks, ReactElement}
 import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.web.html._
-import typings.reactRouterDom.{mod => reactRouterDom}
 
 import scala.util.{Failure, Success}
 
@@ -27,7 +27,7 @@ import scala.util.{Failure, Success}
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val texts = I18nHooks.useMessages(props.ctx.$lang)
-    val history = reactRouterDom.useHistory()
+    val history = useHistory()
     val (formData, setFormData) = Hooks.useState(
       StatefulFormData(
         SignInFormData.initial(

--- a/web/src/main/scala/net/wiringbits/components/widgets/SignUpForm.scala
+++ b/web/src/main/scala/net/wiringbits/components/widgets/SignUpForm.scala
@@ -10,13 +10,13 @@ import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.Container
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.widgets.{CircularLoader, Container, Title}
 import net.wiringbits.webapp.utils.slinkyUtils.forms.StatefulFormData
 import net.wiringbits.AppContext
+import net.wiringbits.webapp.utils.slinkyUtils.facades.reactrouterdom.useHistory
 import org.scalajs.dom
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 import slinky.core.annotations.react
 import slinky.core.facade.{Fragment, Hooks}
 import slinky.core.{FunctionalComponent, SyntheticEvent}
 import slinky.web.html._
-import typings.reactRouterDom.{mod => reactRouterDom}
 
 import scala.util.{Failure, Success}
 
@@ -25,7 +25,7 @@ import scala.util.{Failure, Success}
 
   val component: FunctionalComponent[Props] = FunctionalComponent[Props] { props =>
     val texts = I18nHooks.useMessages(props.ctx.$lang)
-    val history = reactRouterDom.useHistory()
+    val history = useHistory()
     val (formData, setFormData) = Hooks.useState(
       StatefulFormData(
         SignUpFormData.initial(

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -109,11 +109,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/history@*":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
 "@types/json-schema@^7.0.5":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -154,31 +149,6 @@
   resolved "https://registry.yarnpkg.com/@types/react-google-recaptcha/-/react-google-recaptcha-2.1.0.tgz#49f544cdbaea1f27227297a8466b6f2d96a165fd"
   integrity sha512-gOwTA3YYTr4gOvnbJf3ikYvVpvn/5oalxTGXk2ASo9wCspeoe86i2+cifBnxFsKw0QbBt0djj/C69vctmQUIIg==
   dependencies:
-    "@types/react" "*"
-
-"@types/react-router-dom@5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.2.tgz#853f229f1f297513c0be84f7c914a08b778cfdf5"
-  integrity sha512-kRx8hoBflE4Dp7uus+j/0uMHR5uGTAvQtc4A3vOTWKS+epe0leCuxEx7HNT7XGUd1lH53/moWM51MV2YUyhzAg==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-    "@types/react-router" "*"
-
-"@types/react-router@*":
-  version "5.1.11"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.11.tgz#b01ce4cb21bf7d6b32edc862fc1e2c0088044b5b"
-  integrity sha512-ofHbZMlp0Y2baOHgsWBQ4K3AttxY61bDMkwTiBOkPg7U6C/3UwwB5WaIx28JmSVi/eX3uFEMRo61BV22fDQIvg==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-
-"@types/react-router@5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.2.tgz#41e5e6aa333a7b9a2bfdac753c04e1ca4b3e0d21"
-  integrity sha512-euC3SiwDg3NcjFdNmFL8uVuAFTpZJm0WMFUw+4eXMUnxa7M9RGFEG0szt0z+/Zgk4G2k9JBFhaEnY64RBiFmuw==
-  dependencies:
-    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react-transition-group@^2.0.8":


### PR DESCRIPTION
Updating webapp-utils. 
This adds our own facades for react-route so we don't need to generate Scalablytyped react-route facades