### PR TITLE
Add missing tapir dependency to API and remove hot initialize from web

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,7 +252,8 @@ lazy val api = (crossProject(JSPlatform, JVMPlatform) in file("lib/api"))
   .jvmSettings(
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % playJson,
-      "com.softwaremill.sttp.client3" %% "core" % sttp
+      "com.softwaremill.sttp.client3" %% "core" % sttp,
+      "com.softwaremill.sttp.tapir" %% "tapir-core" % tapir
     )
   )
   .jsSettings(
@@ -264,7 +265,8 @@ lazy val api = (crossProject(JSPlatform, JVMPlatform) in file("lib/api"))
       "com.typesafe.play" %%% "play-json" % playJson,
       "com.softwaremill.sttp.client3" %%% "core" % sttp,
       "org.scalatest" %%% "scalatest" % "3.2.16" % Test,
-      "com.beachape" %%% "enumeratum" % enumeratum
+      "com.beachape" %%% "enumeratum" % enumeratum,
+      "com.softwaremill.sttp.tapir" %%% "tapir-core" % tapir
     )
   )
 

--- a/web/src/main/scala/net/wiringbits/Main.scala
+++ b/web/src/main/scala/net/wiringbits/Main.scala
@@ -6,11 +6,10 @@ import net.wiringbits.core.I18nLang
 import net.wiringbits.models.AuthState
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.{ErrorBoundaryComponent, ErrorBoundaryInfo}
 import org.scalajs.dom
-import slinky.hot
 import slinky.web.ReactDOM
 
+import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
-import scala.scalajs.{LinkingInfo, js}
 
 @JSImport("js/index.css", JSImport.Default)
 @js.native
@@ -20,10 +19,6 @@ object Main {
   val css = IndexCSS
 
   def main(argv: Array[String]): Unit = {
-    if (LinkingInfo.developmentMode) {
-      hot.initialize()
-    }
-
     val scheduler = monix.execution.Scheduler.global
     val $authState = Var[AuthState](AuthState.Unauthenticated)(scheduler)
     val $lang = Var[I18nLang](I18nLang.English)(scheduler)


### PR DESCRIPTION
Slinky hot initialize prevents the web to load for some reason, so we have to remove it to load correctly the web