### PR TITLE
Swagger config and base path for swagger

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -1,18 +1,13 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
 # Swagger - be aware these are used at compile time
-api.version = "beta"
 swagger {
   api {
-    basepath = "/"
-    basepath = ${?SWAGGER_API_BASEPATH}
-
-    # avoids setting the value to localhost
-    # see https://github.com/dwickern/swagger-play/issues/9
-    host = ""
-    host = ${?SWAGGER_API_HOST}
+    basePath = ""
+    basePath = ${?SWAGGER_API_BASEPATH}
 
     info = {
+      version = "beta"
       contact = "template@wiringbits.net"
       title = "Scala webapp template's API"
       description = "The API for the Scala webapp template app"

--- a/server/src/main/scala/controllers/ApiRoutes.scala
+++ b/server/src/main/scala/controllers/ApiRoutes.scala
@@ -1,26 +1,33 @@
 package controllers
 
 import akka.stream.Materializer
+import net.wiringbits.config.SwaggerConfig
 import play.api.libs.ws.StandaloneWSClient
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 import sttp.apispec.openapi.Info
 import sttp.tapir.PublicEndpoint
 import sttp.tapir.server.play.PlayServerInterpreter
+import sttp.tapir.swagger.SwaggerUIOptions
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class ApiRoutes @Inject() (implicit materializer: Materializer, wsClient: StandaloneWSClient, ec: ExecutionContext)
-    extends SimpleRouter {
-  private val swagger = SwaggerInterpreter()
+class ApiRoutes @Inject() (swaggerConfig: SwaggerConfig)(implicit
+    materializer: Materializer,
+    wsClient: StandaloneWSClient,
+    ec: ExecutionContext
+) extends SimpleRouter {
+  private val swagger = SwaggerInterpreter(
+    swaggerUIOptions = SwaggerUIOptions.default.copy(contextPath = List(swaggerConfig.basePath))
+  )
     .fromEndpoints[Future](
       ApiRoutes.routes,
       Info(
-        title = "Scala webapp template's API",
-        version = "beta",
-        description = Some("The API for the Scala webapp template app")
+        title = swaggerConfig.info.title,
+        version = swaggerConfig.info.version,
+        description = Some(swaggerConfig.info.description)
       )
     )
 

--- a/server/src/main/scala/net/wiringbits/config/SwaggerConfig.scala
+++ b/server/src/main/scala/net/wiringbits/config/SwaggerConfig.scala
@@ -1,0 +1,25 @@
+package net.wiringbits.config
+
+import play.api.Configuration
+
+case class SwaggerConfig(basePath: String, info: SwaggerConfig.Info) {
+  override def toString: String = s"SwaggerConfig($basePath, $info)"
+}
+
+object SwaggerConfig {
+  case class Info(version: String, contact: String, title: String, description: String) {
+    override def toString: String = s"Info($version, $contact, $title, $description)"
+  }
+
+  def apply(config: Configuration): SwaggerConfig = {
+    val apiConfig = config.get[Configuration]("api")
+    val apiInfoConfig = apiConfig.get[Configuration]("info")
+
+    val basePath = apiConfig.get[String]("basePath")
+    val version = apiInfoConfig.get[String]("version")
+    val contact = apiInfoConfig.get[String]("contact")
+    val title = apiInfoConfig.get[String]("title")
+    val description = apiInfoConfig.get[String]("description")
+    SwaggerConfig(basePath, Info(version, contact, title, description))
+  }
+}

--- a/server/src/main/scala/net/wiringbits/modules/ConfigModule.scala
+++ b/server/src/main/scala/net/wiringbits/modules/ConfigModule.scala
@@ -58,4 +58,12 @@ class ConfigModule extends AbstractModule {
     logger.info(s"Config loaded: $config")
     config
   }
+
+  @Provides
+  @Singleton
+  def swaggerConfig(global: Configuration): SwaggerConfig = {
+    val config = SwaggerConfig(global.get[Configuration]("swagger"))
+    logger.info(s"Config loaded: $config")
+    config
+  }
 }


### PR DESCRIPTION
Fixes endpoints base path in swagger

### This will break the current config from our scripts
Changes in application.conf:
- Moved `api.version` to `swagger.api.info.version`
- `swagger.api.basepath` renamed to `swagger.api.basePath`
- Removed `swagger.api.host`