### PR TITLE
Change ReactDom.render to createRoot (React 18 render)

### DIFF
--- a/web/src/main/scala/net/wiringbits/Main.scala
+++ b/web/src/main/scala/net/wiringbits/Main.scala
@@ -6,7 +6,7 @@ import net.wiringbits.core.I18nLang
 import net.wiringbits.models.AuthState
 import net.wiringbits.webapp.utils.slinkyUtils.components.core.{ErrorBoundaryComponent, ErrorBoundaryInfo}
 import org.scalajs.dom
-import slinky.web.ReactDOM
+import typings.reactDom.clientMod.createRoot
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
@@ -37,6 +37,6 @@ object Main {
       )
     )
 
-    ReactDOM.render(app, dom.document.getElementById("root"))
+    createRoot(dom.document.getElementById("root")).render(app)
   }
 }


### PR DESCRIPTION
Fixes React 18 console warning
```
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. 
Until you switch to the new API, your app will behave as if it's running React 17. 
Learn more: https://reactjs.org/link/switch-to-createroot
```